### PR TITLE
Fix Buffer for node v10 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-- node
+- 6
+- 8
+- 10
 - lts/*
 script: gulp test
 before_install:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ xdr.Bool.fromXDR([0,0,0,0]) // returns false
 xdr.Bool.fromXDR([0,0,0,1]) // returns true
 
 // the inverse of `fromXDR` is `toXDR`, which returns a Buffer
-xdr.Bool.toXDR(true) // returns new Buffer([0,0,0,1])
+xdr.Bool.toXDR(true) // returns Buffer.from([0,0,0,1])
 
 // XDR ints and unsigned ints can be safely represented as
 // a javascript number

--- a/examples/enum.js
+++ b/examples/enum.js
@@ -22,7 +22,7 @@ console.log(xdr.Color.members()); // { red: 0, green: 1, blue: 2, }
 
 console.log(xdr.Color.fromName("red"));
 
-console.log(xdr.Color.fromXDR(new Buffer([0,0,0,0]))); // Color.red
+console.log(xdr.Color.fromXDR(Buffer.from([0,0,0,0]))); // Color.red
 console.log(xdr.Color.red().toXDR()); // Buffer
 console.log(xdr.Color.red().toXDR("hex")); //
 

--- a/examples/struct.js
+++ b/examples/struct.js
@@ -15,13 +15,12 @@ let xdr = XDR.config(xdr => {
 });
 
 let sig = new xdr.Signature();
-sig.publicKey(new Buffer(32));
-sig.publicKey().fill(0x00);
-sig.data(new Buffer("00000000000000000000000000000000"));
+sig.publicKey(Buffer.alloc(32));
+sig.data(Buffer.from("00000000000000000000000000000000"));
 
 let env = new xdr.Envelope({
   signature: sig,
-  body: new Buffer("hello"),
+  body: Buffer.from("hello"),
   timestamp: Math.floor(new Date() / 1000)
 });
 

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -5,8 +5,7 @@ export class Cursor extends BaseCursor {
 
   writeBufferPadded(buffer) {
     let padding = calculatePadding(buffer.length);
-    let paddingBuffer = new Buffer(padding);
-    paddingBuffer.fill(0);
+    let paddingBuffer = Buffer.alloc(padding);
     
     return this
       .copyFrom(new Cursor(buffer))

--- a/src/io-mixin.js
+++ b/src/io-mixin.js
@@ -19,8 +19,8 @@ var staticMethods = {
     let buffer;
     switch(format) {
       case "raw":    buffer = input; break;
-      case "hex":    buffer = new Buffer(input, "hex"); break;
-      case "base64": buffer = new Buffer(input, "base64"); break;
+      case "hex":    buffer = Buffer.from(input, "hex"); break;
+      case "base64": buffer = Buffer.from(input, "base64"); break;
       default:
         throw new Error(`Invalid format ${format}, must be "raw", "hex", "base64"`);
     }

--- a/src/string.js
+++ b/src/string.js
@@ -34,7 +34,7 @@ export class String {
     if(!isString(value)) {
       throw new Error(`XDR Write Error: ${value} is not a string,`);
     }
-    let buffer = new Buffer(value, 'utf8');
+    let buffer = Buffer.from(value, 'utf8');
     
     Int.write(buffer.length, io);
     io.writeBufferPadded(buffer);
@@ -44,7 +44,7 @@ export class String {
     if (!isString(value)) {
       return false;
     }
-    let buffer = new Buffer(value, 'utf8');
+    let buffer = Buffer.from(value, 'utf8');
     return buffer.length <= this._maxLength;
   }
 }

--- a/test/unit/opaque_test.js
+++ b/test/unit/opaque_test.js
@@ -7,8 +7,8 @@ let subject = new Opaque(3);
 describe('Opaque#read', function() {
 
   it('decodes correctly', function() {
-    expect(read([0,0,0,0])).to.eql(new Buffer([0,0,0]));
-    expect(read([0,0,1,0])).to.eql(new Buffer([0,0,1]));
+    expect(read([0,0,0,0])).to.eql(Buffer.from([0,0,0]));
+    expect(read([0,0,1,0])).to.eql(Buffer.from([0,0,1]));
   });
 
   it('throws a read error if the padding bytes are not zero', function() {    
@@ -24,8 +24,8 @@ describe('Opaque#read', function() {
 describe('Opaque#write', function() {
 
   it('encodes correctly', function() {
-    expect(write(new Buffer([0,0,0]))).to.eql([0,0,0,0]);
-    expect(write(new Buffer([0,0,1]))).to.eql([0,0,1,0]);
+    expect(write(Buffer.from([0,0,0]))).to.eql([0,0,0,0]);
+    expect(write(Buffer.from([0,0,1]))).to.eql([0,0,1,0]);
   });
 
   function write(value) {
@@ -37,12 +37,12 @@ describe('Opaque#write', function() {
 
 describe('Opaque#isValid', function() {
   it('returns true for buffers of the correct length', function() {
-    expect(subject.isValid(new Buffer(3))).to.be.true;
+    expect(subject.isValid(Buffer.alloc(3))).to.be.true;
   });
 
   it('returns false for buffers of the wrong size', function() {
-    expect(subject.isValid(new Buffer(2))).to.be.false;
-    expect(subject.isValid(new Buffer(4))).to.be.false;
+    expect(subject.isValid(Buffer.alloc(2))).to.be.false;
+    expect(subject.isValid(Buffer.alloc(4))).to.be.false;
   });
 
   it('returns false for non buffers', function() {

--- a/test/unit/var-opaque_test.js
+++ b/test/unit/var-opaque_test.js
@@ -7,10 +7,10 @@ let subject = new VarOpaque(2);
 describe('VarOpaque#read', function() {
 
   it('decodes correctly', function() {
-    expect(read([0,0,0,0])).to.eql(new Buffer([]));
-    expect(read([0,0,0,1,0,0,0,0])).to.eql(new Buffer([0]));
-    expect(read([0,0,0,1,1,0,0,0])).to.eql(new Buffer([1]));
-    expect(read([0,0,0,2,0,1,0,0])).to.eql(new Buffer([0,1]));
+    expect(read([0,0,0,0])).to.eql(Buffer.from([]));
+    expect(read([0,0,0,1,0,0,0,0])).to.eql(Buffer.from([0]));
+    expect(read([0,0,0,1,1,0,0,0])).to.eql(Buffer.from([1]));
+    expect(read([0,0,0,2,0,1,0,0])).to.eql(Buffer.from([0,1]));
   });
 
   it("throws a read error when the encoded length is greater than the allowed max", function() {
@@ -32,10 +32,10 @@ describe('VarOpaque#read', function() {
 describe('VarOpaque#write', function() {
 
   it('encodes correctly', function() {
-    expect(write(new Buffer([]))).to.eql([0,0,0,0]);
-    expect(write(new Buffer([0]))).to.eql([0,0,0,1,0,0,0,0]);
-    expect(write(new Buffer([1]))).to.eql([0,0,0,1,1,0,0,0]);
-    expect(write(new Buffer([0,1]))).to.eql([0,0,0,2,0,1,0,0]);
+    expect(write(Buffer.from([]))).to.eql([0,0,0,0]);
+    expect(write(Buffer.from([0]))).to.eql([0,0,0,1,0,0,0,0]);
+    expect(write(Buffer.from([1]))).to.eql([0,0,0,1,1,0,0,0]);
+    expect(write(Buffer.from([0,1]))).to.eql([0,0,0,2,0,1,0,0]);
   });
 
   function write(value) {
@@ -47,14 +47,14 @@ describe('VarOpaque#write', function() {
 
 describe('VarOpaque#isValid', function() {
   it('returns true for buffers of the correct length', function() {
-    expect(subject.isValid(new Buffer(0))).to.be.true;
-    expect(subject.isValid(new Buffer(1))).to.be.true;
-    expect(subject.isValid(new Buffer(2))).to.be.true;
+    expect(subject.isValid(Buffer.alloc(0))).to.be.true;
+    expect(subject.isValid(Buffer.alloc(1))).to.be.true;
+    expect(subject.isValid(Buffer.alloc(2))).to.be.true;
   });
 
   it('returns false for buffers of the wrong size', function() {
-    expect(subject.isValid(new Buffer(3))).to.be.false;
-    expect(subject.isValid(new Buffer(3000))).to.be.false;
+    expect(subject.isValid(Buffer.alloc(3))).to.be.false;
+    expect(subject.isValid(Buffer.alloc(3000))).to.be.false;
   });
 
   it('returns false for non buffers', function() {


### PR DESCRIPTION
@bartekn for other [buffer node deprecation](https://github.com/stellar/js-stellar-base/commit/98cad179cdf85febc60a65cf9fb29391382373fc) PR I updated travis so that it used node 10 in the matrix. However this has a different travis setup. How can I make sure travis tests against node v10?