### PR TITLE
`config` function returns local `types` map

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,12 +6,7 @@ import each from "lodash/each";
 import map from "lodash/map";
 import pick from "lodash/pick";
 
-
-// types is the root
-var types = {};
-
-
-export function config(fn) {
+export function config(fn, types = {}) {
   if (fn) {
     let builder = new TypeBuilder(types);
     fn(builder);

--- a/test/unit/define_test.js
+++ b/test/unit/define_test.js
@@ -27,6 +27,23 @@ describe('XDR.config', function() {
     expect(this.types.ResultType).to.be.truthy;
   });
 
+  it('can define objects with the same name from different contexts', function() {
+    XDR.config(xdr => {
+      xdr.enum('Color', {
+        red: 0,
+        green: 1,
+        blue: 2,
+      });
+    });
+
+    XDR.config(xdr => {
+      xdr.enum('Color', {
+        red: 0,
+        green: 1,
+        blue: 2,
+      });
+    });
+  });
 
   it('can define objects that have simple dependencies', function() {
     XDR.config(xdr => {
@@ -46,7 +63,7 @@ describe('XDR.config', function() {
         ok: 0,
         error: 1
       });
-    });
+    }, this.types);
 
     expect(this.types.Result).to.be.truthy;
     expect(this.types.ResultType).to.be.truthy;
@@ -67,7 +84,7 @@ describe('XDR.config', function() {
         ["green", xdr.int()],
         ["blue", xdr.int()],
       ]);
-    });
+    }, this.types);
 
     expect(this.types.Color).to.be.truthy;
 


### PR DESCRIPTION
Currently `config` function adds new types to the global `types` map and it makes `js-xdr` impossible to use with different XDR schemes inside a single project (with the same types names) but also when multiple versions of `stellar-base` are included in a project (like in https://github.com/stellar/js-stellar-sdk/issues/191).

I removed the global `types` variable and to make it possible to add new types for an existing context I added a second argument to `config` function (with default value of `{}`).