### PR TITLE
split out reference class to it's own file to avoid circular import

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,8 @@ import each from 'lodash/each';
 import * as XDRTypes from './types';
 import { Reference } from './reference';
 
+export * from './reference';
+
 export function config(fn, types = {}) {
   if (fn) {
     const builder = new TypeBuilder(types);

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,6 @@
 import isUndefined from 'lodash/isUndefined';
 import each from 'lodash/each';
 import * as XDRTypes from './types';
-import { Reference } from './reference';
 
 export function config(fn, types = {}) {
   if (fn) {
@@ -11,6 +10,13 @@ export function config(fn, types = {}) {
   }
 
   return types;
+}
+
+export class Reference {
+  /* jshint unused: false */
+  resolve() {
+    throw new Error('implement resolve in child class');
+  }
 }
 
 class SimpleReference extends Reference {

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 import isUndefined from 'lodash/isUndefined';
 import each from 'lodash/each';
 import * as XDRTypes from './types';
+import { Reference } from './reference';
 
 export function config(fn, types = {}) {
   if (fn) {
@@ -10,13 +11,6 @@ export function config(fn, types = {}) {
   }
 
   return types;
-}
-
-export class Reference {
-  /* jshint unused: false */
-  resolve() {
-    throw new Error('implement resolve in child class');
-  }
 }
 
 class SimpleReference extends Reference {

--- a/src/reference.js
+++ b/src/reference.js
@@ -1,0 +1,6 @@
+export class Reference {
+  /* jshint unused: false */
+  resolve() {
+    throw new Error('implement resolve in child class');
+  }
+}

--- a/src/reference.js
+++ b/src/reference.js
@@ -1,6 +1,0 @@
-export class Reference {
-  /* jshint unused: false */
-  resolve() {
-    throw new Error('implement resolve in child class');
-  }
-}

--- a/src/struct.js
+++ b/src/struct.js
@@ -2,7 +2,7 @@ import each from 'lodash/each';
 import map from 'lodash/map';
 import isUndefined from 'lodash/isUndefined';
 import fromPairs from 'lodash/fromPairs';
-import { Reference } from './config';
+import { Reference } from './reference';
 import includeIoMixin from './io-mixin';
 
 export class Struct {

--- a/src/struct.js
+++ b/src/struct.js
@@ -2,7 +2,7 @@ import each from 'lodash/each';
 import map from 'lodash/map';
 import isUndefined from 'lodash/isUndefined';
 import fromPairs from 'lodash/fromPairs';
-import { Reference } from './reference';
+import { Reference } from './config';
 import includeIoMixin from './io-mixin';
 
 export class Struct {

--- a/src/union.js
+++ b/src/union.js
@@ -3,7 +3,7 @@ import each from 'lodash/each';
 import isUndefined from 'lodash/isUndefined';
 import isString from 'lodash/isString';
 import { Void } from './void';
-import { Reference } from './reference';
+import { Reference } from './config';
 import includeIoMixin from './io-mixin';
 
 export class Union {

--- a/src/union.js
+++ b/src/union.js
@@ -3,7 +3,7 @@ import each from 'lodash/each';
 import isUndefined from 'lodash/isUndefined';
 import isString from 'lodash/isString';
 import { Void } from './void';
-import { Reference } from './config';
+import { Reference } from './reference';
 import includeIoMixin from './io-mixin';
 
 export class Union {


### PR DESCRIPTION
After a harrowing voyage into the deep end of using the `@stellar/wallet-sdk` in a Stencil component project I arrived at this PR to fix a circular import issue revolving around rollup. Many component toolchains use rollup to package their dependencies cleanly. This works great most of the time but in the case of the `@stellar/wallet-sdk` there was a very odd issue trickling all the way back to the `js-xdr` library.

In short this issue arises in how rollup packages dependencies and how we're exporting the `Reference` class multiple times. By breaking it out to its own file we can limit its inclusion to only those files which require it and not to the general public via the index.js `export * from './config';` line.

I've tested this through the whole chain at each level of inclusion, `stellar-base`, `stellar-sdk` and `@stellar/wallet-sdk`. Works like a charm.