### PR TITLE
Add helper function to validate XDRs before converting them into a struct.

### DIFF
--- a/src/io-mixin.js
+++ b/src/io-mixin.js
@@ -39,6 +39,15 @@ const staticMethods = {
     // TODO: error out if the entire buffer isn't consumed
 
     return result;
+  },
+
+  validateXDR(input, format = 'raw') {
+    try {
+      this.fromXDR(input, format);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 };
 

--- a/test/unit/struct_test.js
+++ b/test/unit/struct_test.js
@@ -137,6 +137,21 @@ describe('Struct.isValid', function() {
   });
 });
 
+describe('Struct.validateXDR', function() {
+  it('returns true for valid XDRs', function() {
+    let subject = new MyRange({ begin: 5, end: 255, inclusive: true });
+    expect(MyRange.validateXDR(subject.toXDR())).to.be.true;
+    expect(MyRange.validateXDR(subject.toXDR('hex'), 'hex')).to.be.true;
+    expect(MyRange.validateXDR(subject.toXDR('base64'), 'base64')).to.be.true;
+  });
+
+  it('returns false for invalid XDRs', function() {
+    expect(MyRange.validateXDR(Buffer.alloc(1))).to.be.false;
+    expect(MyRange.validateXDR('00', 'hex')).to.be.false;
+    expect(MyRange.validateXDR('AA==', 'base64')).to.be.false;
+  });
+});
+
 describe('Struct: attributes', function() {
   it('properly retrieves attributes', function() {
     let subject = new MyRange({ begin: 5, end: 255, inclusive: true });


### PR DESCRIPTION
Add the class function `validateXDR(input, format)` which returns `true` if the input is a valid XDR for the given struct or `false` otherwise. 

This addresses the issue reported in https://github.com/stellar/js-stellar-sdk/issues/364