### PR TITLE
Inline cursor dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "webpack-stream": "^5.2.1"
   },
   "dependencies": {
-    "cursor": "^0.1.5",
     "lodash": "^4.17.5",
     "long": "^2.2.3"
   }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -1,7 +1,138 @@
-import BaseCursor from 'cursor';
 import { calculatePadding } from './util';
 
-export class Cursor extends BaseCursor {
+class Cursor {
+  constructor(buffer) {
+    if (!(buffer instanceof Buffer)) {
+      buffer =
+        typeof buffer === 'number' ? Buffer.alloc(buffer) : Buffer.from(buffer);
+    }
+
+    this._setBuffer(buffer);
+    this.rewind();
+  }
+
+  _setBuffer(buffer) {
+    this._buffer = buffer;
+    this.length = buffer.length;
+  }
+
+  buffer() {
+    return this._buffer;
+  }
+
+  tap(cb) {
+    cb(this);
+    return this;
+  }
+
+  clone(newIndex) {
+    const c = new this.constructor(this.buffer());
+    c.seek(arguments.length === 0 ? this.tell() : newIndex);
+
+    return c;
+  }
+
+  tell() {
+    return this._index;
+  }
+
+  seek(op, index) {
+    if (arguments.length === 1) {
+      index = op;
+      op = '=';
+    }
+
+    if (op === '+') {
+      this._index += index;
+    } else if (op === '-') {
+      this._index -= index;
+    } else {
+      this._index = index;
+    }
+
+    return this;
+  }
+
+  rewind() {
+    return this.seek(0);
+  }
+
+  eof() {
+    return this.tell() === this.buffer().length;
+  }
+
+  write(string, length, encoding) {
+    return this.seek(
+      '+',
+      this.buffer().write(string, this.tell(), length, encoding)
+    );
+  }
+
+  fill(value, length) {
+    if (arguments.length === 1) {
+      length = this.buffer().length - this.tell();
+    }
+
+    this.buffer().fill(value, this.tell(), this.tell() + length);
+    this.seek('+', length);
+
+    return this;
+  }
+
+  slice(length) {
+    if (arguments.length === 0) {
+      length = this.length - this.tell();
+    }
+
+    const c = new this.constructor(
+      this.buffer().slice(this.tell(), this.tell() + length)
+    );
+    this.seek('+', length);
+
+    return c;
+  }
+
+  copyFrom(source) {
+    const buf = source instanceof Buffer ? source : source.buffer();
+    buf.copy(this.buffer(), this.tell(), 0, buf.length);
+    this.seek('+', buf.length);
+
+    return this;
+  }
+
+  concat(list) {
+    list.forEach((item, i) => {
+      if (item instanceof Cursor) {
+        list[i] = item.buffer();
+      }
+    });
+
+    list.unshift(this.buffer());
+
+    const b = Buffer.concat(list);
+    this._setBuffer(b);
+
+    return this;
+  }
+
+  toString(encoding, length) {
+    if (arguments.length === 0) {
+      encoding = 'utf8';
+      length = this.buffer().length - this.tell();
+    } else if (arguments.length === 1) {
+      length = this.buffer().length - this.tell();
+    }
+
+    const val = this.buffer().toString(
+      encoding,
+      this.tell(),
+      this.tell() + length
+    );
+    this.seek('+', length);
+
+    return val;
+  }
+
   writeBufferPadded(buffer) {
     const padding = calculatePadding(buffer.length);
     const paddingBuffer = Buffer.alloc(padding);
@@ -11,3 +142,57 @@ export class Cursor extends BaseCursor {
     );
   }
 }
+
+[
+  [1, ['readInt8', 'readUInt8']],
+  [2, ['readInt16BE', 'readInt16LE', 'readUInt16BE', 'readUInt16LE']],
+  [
+    4,
+    [
+      'readInt32BE',
+      'readInt32LE',
+      'readUInt32BE',
+      'readUInt32LE',
+      'readFloatBE',
+      'readFloatLE'
+    ]
+  ],
+  [8, ['readDoubleBE', 'readDoubleLE']]
+].forEach((arr) => {
+  arr[1].forEach((method) => {
+    Cursor.prototype[method] = function read() {
+      const val = this.buffer()[method](this.tell());
+      this.seek('+', arr[0]);
+
+      return val;
+    };
+  });
+});
+
+[
+  [1, ['writeInt8', 'writeUInt8']],
+  [2, ['writeInt16BE', 'writeInt16LE', 'writeUInt16BE', 'writeUInt16LE']],
+  [
+    4,
+    [
+      'writeInt32BE',
+      'writeInt32LE',
+      'writeUInt32BE',
+      'writeUInt32LE',
+      'writeFloatBE',
+      'writeFloatLE'
+    ]
+  ],
+  [8, ['writeDoubleBE', 'writeDoubleLE']]
+].forEach((arr) => {
+  arr[1].forEach((method) => {
+    Cursor.prototype[method] = function write(val) {
+      this.buffer()[method](val, this.tell());
+      this.seek('+', arr[0]);
+
+      return this;
+    };
+  });
+});
+
+export { Cursor };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,11 +2130,6 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-cursor@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/cursor/-/cursor-0.1.5.tgz#ea778c2b09d33c2e564fd92147076750483ebb2c"
-  integrity sha1-6neMKwnTPC5WT9khRwdnUEg+uyw=
-
 custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"


### PR DESCRIPTION
Fixes #60

This inlines and modernizes the `cursor` dependency.

This includes the Buffer deprecation https://github.com/dimerica-industries/node-cursor/pull/2 fix here