### PR TITLE
Fix the NPM publication action after previous failures

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,9 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
 
       - name: Install Dependencies
         run: yarn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## [v3.0.1](https://github.com/stellar/js-xdr/compare/v3.0.0...v3.0.1)
+
+### Fixes
+- This package is now being published to `@stellar/js-xdr` on NPM.
+- The versions at `js-xdr` are now considered **deprecated** ([#111](https://github.com/stellar/js-xdr/pull/111)).
+- Misc. dependencies have been upgraded ([#104](https://github.com/stellar/js-xdr/pull/104), [#106](https://github.com/stellar/js-xdr/pull/106), [#107](https://github.com/stellar/js-xdr/pull/107), [#108](https://github.com/stellar/js-xdr/pull/108), [#105](https://github.com/stellar/js-xdr/pull/105)).
+
+
 ## [v3.0.0](https://github.com/stellar/js-xdr/compare/v2.0.0...v3.0.0)
 
 ### Breaking Change


### PR DESCRIPTION
There were failures on [the last attempt](https://github.com/stellar/js-xdr/actions/runs/6935885696/job/18866921067) to publish to npm. Here's the error:

> No token found and can't prompt for login when running with --non-interactive.

According to [actions/setup-node#81](https://github.com/actions/setup-node/issues/81), there are some additional parameters needed to publish to npm and this PR makes those changes.

(Oh yeah, this also adds a changelog because we missed that in #111.)