### PR TITLE
Modify publish script to have public scope

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
         run: yarn build && yarn test
 
       - name: Publish npm package
-        run: yarn publish
+        run: yarn publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Scoped packages are private/paid by default, so we need to ensure access is public.