### PR TITLE
Change deprecation to apply to latest version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,15 +23,15 @@ jobs:
       - name: Build & Test
         run: yarn build && yarn test
 
-      - name: Publish npm package
-        run: yarn publish --access public
+      - name: Publish npm packages
+        run: |
+          yarn publish --access public
+          sed -i -e 's#"@stellar/js-xdr"#"js-xdr"#' package.json
+          yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish npm package under old scope
-        run: |
-          sed -i -e 's#"@stellar/js-xdr"#"js-xdr"#' package.json
-          yarn publish
-          npm deprecate js-xdr "⚠️ This package has moved to @stellar/js-xdr! 🚚"
+        run: npm deprecate@latest js-xdr "⚠️ This package has moved to @stellar/js-xdr! 🚚"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ compound XDR types (enums, structs and unions)
 via npm:
 
 ```shell
-npm install --save js-xdr
+npm install --save @stellar/js-xdr
 ```
 
 ## Usage
@@ -28,7 +28,9 @@ You can find some [examples here](examples/).
 First, let's import the library:
 
 ```javascript
-var xdr = require('js-xdr');
+var xdr = require('@stellar/js-xdr');
+// or
+import xdr from '@stellar/js-xdr';
 ```
 
 Now, let's look at how to decode some primitive types:
@@ -78,13 +80,13 @@ There are a couple of caveats to be aware of with this library:
 
 ## Code generation
 
-js-xdr by itself does not have any ability to parse XDR IDL files and produce a
-parser for your custom data types. Instead, that is the responsibility of
-[xdrgen](http://github.com/stellar/xdrgen). xdrgen will take your .x files and
-produce a javascript file that target this library to allow for your own custom
-types.
+`js-xdr` by itself does not have any ability to parse XDR IDL files and produce
+a parser for your custom data types. Instead, that is the responsibility of
+[`xdrgen`](http://github.com/stellar/xdrgen). xdrgen will take your .x files
+and produce a javascript file that target this library to allow for your own
+custom types.
 
-See [js-stellar-base](http://github.com/stellar/js-stellar-base) for an example
+See [`stellar-base`](http://github.com/stellar/js-stellar-base) for an example
 (check out the src/generated directory)
 
 ## Contributing
@@ -103,7 +105,7 @@ git clone https://github.com/stellar/js-xdr.git
 
 ```shell
 cd js-xdr
-npm install
+npm i
 ```
 
 3. Install Node 14


### PR DESCRIPTION
When looking at the [`js-xdr` npm page](https://www.npmjs.com/package/js-xdr), there is no deprecation message. It's only present when looking at the [previous version](https://www.npmjs.com/package/js-xdr/v/3.0.0). 

This is an attempt to make it apply to the latest version, too.