### PR TITLE
Fix the issue that cannot run in a pre-ES2016 environment.

### DIFF
--- a/buffer.js
+++ b/buffer.js
@@ -1,3 +1,4 @@
+// See https://github.com/stellar/js-xdr/issues/117
 import { Buffer } from 'buffer';
 
 if (!(Buffer.alloc(1).subarray(0, 1) instanceof Buffer)) {

--- a/buffer.js
+++ b/buffer.js
@@ -1,0 +1,11 @@
+import { Buffer } from 'buffer';
+
+if (!(Buffer.alloc(1).subarray(0, 1) instanceof Buffer)) {
+  Buffer.prototype.subarray = function subarray(start, end) {
+    const result = Uint8Array.prototype.subarray.call(this, start, end);
+    Object.setPrototypeOf(result, Buffer.prototype);
+    return result;
+  };
+}
+
+export default Buffer;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = function () {
     };
     config.plugins.push(
       new webpack.ProvidePlugin({
-        Buffer: ['buffer', 'Buffer']
+        Buffer: [path.resolve(__dirname, 'buffer.js'), 'default']
       })
     );
   } else {


### PR DESCRIPTION
Fix #117 

Monkey patch Buffer to make it work in pre-ES2016 environments. I have tested this code in React Native.

If this PR is merged, a new version should be released immediately so that we can update stelar-base and stellar-sdk next.