### PR TITLE
Harden parsing

### DIFF
--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -28,13 +28,12 @@ class ArrayType<T> extends BaseType<T[]> {
           `${path}: array length ${length} exceeds maximum ${this.maxLength}`
         );
       }
-      // Reject a wire-declared count that cannot be backed by the remaining
-      // input. Every element consumes at least zero bytes, so a valid array of
-      // elements that consume >= 1 byte always has length <= remaining; only a
-      // zero-width element (void, opaque(0), empty struct) lets a tiny input
-      // declare millions of elements, which would otherwise loop/allocate
-      // unbounded (OOM / RangeError). `readBytes` guards byte-typed lengths the
-      // same way; this is the equivalent guard for the element-count loop.
+      // Defensive guard: the declared element count must not exceed the number
+      // of bytes remaining. This bounds the decode loop for zero-width element
+      // schemas (void, opaque(0), empty struct), where element reads do not
+      // advance the reader and could otherwise loop/allocate unbounded.
+      // For non-zero-width elements, `readBytes` still enforces exact byte
+      // availability during element decoding.
       if (length > reader.remaining) {
         throw new XdrError(
           `${path}: array length ${length} exceeds remaining ${reader.remaining} byte(s)`

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -28,6 +28,18 @@ class ArrayType<T> extends BaseType<T[]> {
           `${path}: array length ${length} exceeds maximum ${this.maxLength}`
         );
       }
+      // Reject a wire-declared count that cannot be backed by the remaining
+      // input. Every element consumes at least zero bytes, so a valid array of
+      // elements that consume >= 1 byte always has length <= remaining; only a
+      // zero-width element (void, opaque(0), empty struct) lets a tiny input
+      // declare millions of elements, which would otherwise loop/allocate
+      // unbounded (OOM / RangeError). `readBytes` guards byte-typed lengths the
+      // same way; this is the equivalent guard for the element-count loop.
+      if (length > reader.remaining) {
+        throw new XdrError(
+          `${path}: array length ${length} exceeds remaining ${reader.remaining} byte(s)`
+        );
+      }
       return readArray(reader, length, this.element, path);
     } finally {
       reader.exit();

--- a/src/types/struct.ts
+++ b/src/types/struct.ts
@@ -21,6 +21,13 @@ class StructType<
 
   constructor(name: string, fields: Shape) {
     super(name);
+    // '__proto__' is not a legal XDR identifier and cannot be assigned onto a
+    // plain result object without rewriting its prototype; reject it up front.
+    if (Object.getOwnPropertyNames(fields).includes('__proto__')) {
+      throw new XdrError(
+        `${name}: struct field name '__proto__' is not allowed`
+      );
+    }
     this.entries = Object.entries(fields) as [string, XdrType<unknown>][];
   }
 
@@ -50,7 +57,10 @@ class StructType<
     }
     const record = value as Record<string, unknown>;
     for (const [key, schema] of this.entries) {
-      if (!(key in record)) {
+      // Use an own-property check: `'__proto__' in record` is satisfied by the
+      // inherited accessor even when no field was provided, which would bypass
+      // this guard and then read Object.prototype as the field value.
+      if (!Object.prototype.hasOwnProperty.call(record, key)) {
         throw new XdrError(`${path}.${key}: missing struct field`);
       }
       schema._write(record[key], writer, `${path}.${key}`);

--- a/test/unit/array.test.ts
+++ b/test/unit/array.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { array, int32 } from '../../src/index.js';
+import { array, int32, void as voidType, XdrError } from '../../src/index.js';
 import { bytes, toArray, roundTrip, encodeInvalid } from './_helpers.js';
+
+// The documented unbounded idiom array(elem, UNBOUNDED_MAX_LENGTH).
+const UNBOUNDED_MAX_LENGTH = 4294967295;
 
 const schema = array(int32(), 3);
 
@@ -37,6 +40,40 @@ describe('array (variable-length)', () => {
       expect(() =>
         schema.decode(bytes([0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 2]))
       ).toThrow(/exceeds maximum/i);
+    });
+
+    it('rejects a declared element count larger than the remaining input', () => {
+      // Declares 10 elements but only 4 element bytes follow: the count cannot
+      // be backed by the input, so fail fast before the element loop.
+      const wide = array(int32(), 100);
+      const input = bytes([0, 0, 0, 10, 0, 0, 0, 1]);
+      expect(() => wide.decode(input)).toThrow(XdrError);
+      expect(() => wide.decode(input)).toThrow(/exceeds remaining/i);
+    });
+
+    it('does not loop or allocate unbounded for a huge count of zero-width elements', () => {
+      // Regression for the element-count DoS: array(void, MAX) declaring
+      // 0xFFFFFFFF elements from a 4-byte input must fail fast with an
+      // XdrError, not spin/OOM or throw a native RangeError.
+      const voidArray = array(voidType(), UNBOUNDED_MAX_LENGTH);
+      const input = bytes([0xff, 0xff, 0xff, 0xff]);
+
+      let caught: unknown;
+      try {
+        voidArray.decode(input);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(XdrError);
+      expect(caught).not.toBeInstanceOf(RangeError);
+    });
+
+    it('still decodes a zero-width-element array whose count fits the input', () => {
+      // A genuine (if degenerate) zero-width array round-trips: length 0 needs
+      // no element bytes.
+      const voidArray = array(voidType(), 8);
+      expect(voidArray.decode(bytes([0, 0, 0, 0]))).toEqual([]);
+      expect(toArray(voidArray.encode([]))).toEqual([0, 0, 0, 0]);
     });
   });
 

--- a/test/unit/struct.test.ts
+++ b/test/unit/struct.test.ts
@@ -84,4 +84,31 @@ describe('struct', () => {
     const value = { begin: -1, end: 100, inclusive: false };
     expect(roundTrip(Range, value)).toEqual(value);
   });
+
+  describe('inherited field names', () => {
+    it('rejects a field named __proto__ at construction', () => {
+      expect(() =>
+        struct('Bad', { ['__proto__']: int32(), x: int32() })
+      ).toThrow(/'__proto__' is not allowed/);
+    });
+
+    it('throws when a field shadowing Object.prototype is missing, rather than encoding the inherited value', () => {
+      const Shadow = struct('Shadow', { toString: int32(), x: int32() });
+      // `'toString' in value` is true for any plain object; only an
+      // own-property check catches the missing field.
+      expect(() => encodeInvalid(Shadow, { x: 7 })).toThrow(
+        /missing struct field/i
+      );
+    });
+
+    it('round-trips a provided field that shadows Object.prototype', () => {
+      const Shadow = struct('Shadow', { toString: int32(), x: int32() });
+      const wire = bytes([0, 0, 0, 5, 0, 0, 0, 7]);
+      const decoded = Shadow.decode(wire);
+      expect(Object.getOwnPropertyDescriptor(decoded, 'toString')?.value).toBe(
+        5
+      );
+      expect(toArray(Shadow.encode(decoded))).toEqual(Array.from(wire));
+    });
+  });
 });


### PR DESCRIPTION
## Harden decoding and struct field handling against malformed input

Two defensive fixes, no API changes.

**Reject wire-declared array counts that exceed remaining input** (`array.ts`)

A variable-length array of zero-width elements (`void`, `opaque(0)`, empty struct) could declare up to 2³²−1 elements from a 4-byte input, driving an unbounded loop/allocation (OOM or native `RangeError`). Decoding now fails fast with an `XdrError` when the declared count exceeds the bytes remaining — the element-count analogue of the existing `readBytes` guard. Trade-off: a valid non-empty array of purely zero-width elements is also rejected, since it's indistinguishable from the attack; empty ones still round-trip.

**Reject `__proto__` as a struct field name; fix inherited-property field checks** (`struct.ts`)

- `struct()` now throws at construction if a field is named `__proto__`: plain assignment during decode would invoke the inherited prototype setter instead of creating a property, so the field can't be represented correctly (it's also not a legal XDR identifier).
- Encoding now uses an own-property check instead of `in` for missing-field detection, so a missing field that shadows `Object.prototype` (e.g. `toString`, `constructor`) throws `missing struct field` rather than silently encoding the inherited value.

Both paths have unit tests covering the failure modes and round-trip behavior.