### PR TITLE
V5 api fixes

### DIFF
--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -51,12 +51,12 @@ export function assertBigIntRange(
   }
 }
 
-export function assertFiniteNumber(
+export function assertNumber(
   value: unknown,
   path: string
 ): asserts value is number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new XdrError(`${path}: expected finite number`);
+  if (typeof value !== 'number') {
+    throw new XdrError(`${path}: expected number`);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,6 @@ export { string } from './types/string.js';
 export { struct } from './types/struct.js';
 export { uint32 } from './types/uint32.js';
 export { uint64 } from './types/uint64.js';
-export { union, case, field } from './types/union.js';
+export { union, case, unionCase, field } from './types/union.js';
 export { varOpaque } from './types/var-opaque.js';
-export { void } from './types/void.js';
+export { void, voidType } from './types/void.js';

--- a/src/types/double.ts
+++ b/src/types/double.ts
@@ -1,7 +1,7 @@
 import type { Reader } from '../core/reader.js';
 import type { Writer } from '../core/writer.js';
 import { BaseType, type XdrType } from '../core/xdr-type.js';
-import { assertFiniteNumber } from '../core/helpers.js';
+import { assertNumber } from '../core/helpers.js';
 
 /**
  * Reads and writes XDR double-precision floating point values.
@@ -14,7 +14,7 @@ class DoubleType extends BaseType<number> {
   }
 
   _write(value: number, writer: Writer, path: string): void {
-    assertFiniteNumber(value, path);
+    assertNumber(value, path);
     writer.writeFloat64(value);
   }
 }
@@ -22,8 +22,10 @@ class DoubleType extends BaseType<number> {
 /**
  * Creates a schema for the XDR double-precision floating point primitive.
  *
- * Values are finite JavaScript numbers encoded as IEEE-754 binary64 values.
- * Encoding rejects `NaN`, `Infinity`, and `-Infinity`.
+ * Values are JavaScript numbers encoded as IEEE-754 binary64 values. `NaN`,
+ * `Infinity`, and `-Infinity` are valid IEEE-754 values and round-trip; `NaN`
+ * always encodes as the canonical quiet NaN, so NaN payload bits from decoded
+ * input are not preserved on re-encode.
  */
 export function double(): XdrType<number> {
   return new DoubleType();

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -21,6 +21,9 @@ export type EnumSchema<
 } & Values;
 
 const RESERVED_ENUM_MEMBER_NAMES = new Set([
+  // Assigning '__proto__' onto the schema would invoke the inherited prototype
+  // setter instead of defining a member constant.
+  '__proto__',
   'name',
   'kind',
   'encode',
@@ -98,9 +101,11 @@ export class EnumType<Values extends Record<string, number>> extends BaseType<
  */
 export function enumType<
   Name extends string,
-  Values extends Record<string, number>
+  const Values extends Record<string, number>
 >(name: Name, values: Values): EnumSchema<Name, Values> {
-  for (const memberName of Object.keys(values)) {
+  // getOwnPropertyNames (not Object.keys) so a computed ['__proto__'] key is
+  // caught; the plain `__proto__:` literal form never creates an own key.
+  for (const memberName of Object.getOwnPropertyNames(values)) {
     if (RESERVED_ENUM_MEMBER_NAMES.has(memberName)) {
       throw new XdrError(
         `${name}: enum member name ${memberName} collides with reserved property`

--- a/src/types/float.ts
+++ b/src/types/float.ts
@@ -1,7 +1,7 @@
 import type { Reader } from '../core/reader.js';
 import type { Writer } from '../core/writer.js';
 import { BaseType, type XdrType } from '../core/xdr-type.js';
-import { assertFiniteNumber } from '../core/helpers.js';
+import { assertNumber } from '../core/helpers.js';
 
 /**
  * Reads and writes XDR single-precision floating point values.
@@ -14,7 +14,7 @@ class FloatType extends BaseType<number> {
   }
 
   _write(value: number, writer: Writer, path: string): void {
-    assertFiniteNumber(value, path);
+    assertNumber(value, path);
     writer.writeFloat32(value);
   }
 }
@@ -22,8 +22,10 @@ class FloatType extends BaseType<number> {
 /**
  * Creates a schema for the XDR single-precision floating point primitive.
  *
- * Values are finite JavaScript numbers encoded as IEEE-754 binary32 values.
- * Encoding rejects `NaN`, `Infinity`, and `-Infinity`.
+ * Values are JavaScript numbers encoded as IEEE-754 binary32 values. `NaN`,
+ * `Infinity`, and `-Infinity` are valid IEEE-754 values and round-trip; `NaN`
+ * always encodes as the canonical quiet NaN, so NaN payload bits from decoded
+ * input are not preserved on re-encode.
  */
 export function float(): XdrType<number> {
   return new FloatType();

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -86,9 +86,9 @@ class UnionType<
     switchKey: SwitchKey
   ) {
     super(name);
-    // Same rationale as struct: '__proto__' cannot be assigned onto a plain
-    // value object without invoking the inherited prototype setter, and the
-    // `in`-based presence checks below would read Object.prototype for it.
+    // Same rationale as struct: '__proto__' cannot be defined as an own property on
+    // a plain object without invoking the inherited prototype setter, so it is
+    // not a legal discriminator field name.
     if (switchKey === '__proto__') {
       throw new XdrError(`${name}: switchKey '__proto__' is not allowed`);
     }

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -86,6 +86,12 @@ class UnionType<
     switchKey: SwitchKey
   ) {
     super(name);
+    // Same rationale as struct: '__proto__' cannot be assigned onto a plain
+    // value object without invoking the inherited prototype setter, and the
+    // `in`-based presence checks below would read Object.prototype for it.
+    if (switchKey === '__proto__') {
+      throw new XdrError(`${name}: switchKey '__proto__' is not allowed`);
+    }
     this.switchOn = switchOn;
     this.cases = cases;
     this.defaultArm = defaultArm;
@@ -147,7 +153,10 @@ class UnionType<
     writer: Writer,
     path: string
   ): void {
-    if (!isPlainObject(value) || !(this.switchKey in value)) {
+    if (
+      !isPlainObject(value) ||
+      !Object.prototype.hasOwnProperty.call(value, this.switchKey)
+    ) {
       throw new XdrError(
         `${path}: expected union object with ${this.switchKey} discriminator`
       );
@@ -199,6 +208,9 @@ function case_<
 }
 
 export { case_ as case };
+// `import { case }` is a syntax error, so consumers of the `case` export must
+// alias it; `unionCase` is the same helper under an importable name.
+export { case_ as unionCase };
 
 /**
  * Creates a schema for an XDR union.
@@ -277,7 +289,7 @@ function writeUnionArm(
   path: string
 ): void {
   if (isFieldArm(arm)) {
-    if (!(arm.name in value)) {
+    if (!Object.prototype.hasOwnProperty.call(value, arm.name)) {
       throw new XdrError(`${path}.${arm.name}: missing union arm payload`);
     }
     arm.schema._write(value[arm.name], writer, `${path}.${arm.name}`);
@@ -295,6 +307,11 @@ function assertArmPayloadName(
   if (isFieldArm(arm) && arm.name === switchKey) {
     throw new XdrError(
       `${unionName}.${caseName}: union arm payload field must not be named ${switchKey}`
+    );
+  }
+  if (isFieldArm(arm) && arm.name === '__proto__') {
+    throw new XdrError(
+      `${unionName}.${caseName}: union arm payload field name '__proto__' is not allowed`
     );
   }
 }

--- a/src/types/void.ts
+++ b/src/types/void.ts
@@ -30,3 +30,6 @@ function void_(): XdrType<void> {
 }
 
 export { void_ as void };
+// `import { void }` is a syntax error, so consumers of the `void` export must
+// alias it; `voidType` is the same schema under an importable name.
+export { void_ as voidType };

--- a/test/unit/double.test.ts
+++ b/test/unit/double.test.ts
@@ -20,16 +20,52 @@ describe('double', () => {
       expect(toArray(schema.encode(-2))).toEqual([192, 0, 0, 0, 0, 0, 0, 0]);
     });
 
-    it('throws on non-finite numbers', () => {
-      expect(() => schema.encode(NaN)).toThrow(/finite/i);
-      expect(() => schema.encode(-Infinity)).toThrow(/finite/i);
-      expect(() => encodeInvalid(schema, '1')).toThrow(/finite/i);
+    it('throws on non-number input', () => {
+      expect(() => encodeInvalid(schema, '1')).toThrow(/expected number/i);
+    });
+
+    it('encodes IEEE-754 specials to their wire representations', () => {
+      expect(toArray(schema.encode(Infinity))).toEqual([
+        0x7f, 0xf0, 0, 0, 0, 0, 0, 0
+      ]);
+      expect(toArray(schema.encode(-Infinity))).toEqual([
+        0xff, 0xf0, 0, 0, 0, 0, 0, 0
+      ]);
+      // NaN encodes as the canonical quiet NaN.
+      expect(toArray(schema.encode(NaN))).toEqual([
+        0x7f, 0xf8, 0, 0, 0, 0, 0, 0
+      ]);
+      // -0 keeps its sign bit.
+      expect(toArray(schema.encode(-0))).toEqual([0x80, 0, 0, 0, 0, 0, 0, 0]);
     });
   });
 
+  it('decodes IEEE-754 specials from the wire', () => {
+    expect(schema.decode(bytes([0x7f, 0xf0, 0, 0, 0, 0, 0, 0]))).toBe(Infinity);
+    expect(schema.decode(bytes([0xff, 0xf0, 0, 0, 0, 0, 0, 0]))).toBe(
+      -Infinity
+    );
+    expect(schema.decode(bytes([0x7f, 0xf8, 0, 0, 0, 0, 0, 0]))).toBeNaN();
+    expect(
+      Object.is(schema.decode(bytes([0x80, 0, 0, 0, 0, 0, 0, 0])), -0)
+    ).toBe(true);
+  });
+
   it('round-trips representable values', () => {
-    for (const value of [0, 1, -1, 0.1, -2, 3.141592653589793, 1e308]) {
+    for (const value of [
+      0,
+      1,
+      -1,
+      0.1,
+      -2,
+      3.141592653589793,
+      1e308,
+      Number.MIN_VALUE,
+      Infinity,
+      -Infinity
+    ]) {
       expect(roundTrip(schema, value)).toBe(value);
     }
+    expect(roundTrip(schema, NaN)).toBeNaN();
   });
 });

--- a/test/unit/enum.test.ts
+++ b/test/unit/enum.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { enumType } from '../../src/index.js';
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { enumType, type Infer } from '../../src/index.js';
 import { bytes, toArray, encodeInvalid } from './_helpers.js';
 
 const Color = enumType('Color', { red: 0, green: 1, blue: 2 });
@@ -19,7 +19,8 @@ describe('enum', () => {
     });
 
     it('throws on an unknown value', () => {
-      expect(() => Color.encode(9)).toThrow(/unknown enum value/i);
+      // 9 is now also a compile-time error thanks to literal member types.
+      expect(() => encodeInvalid(Color, 9)).toThrow(/unknown enum value/i);
       expect(() => encodeInvalid(Color, 'red')).toThrow(/unknown enum value/i);
     });
   });
@@ -70,5 +71,18 @@ describe('enum', () => {
         enumType('Bounds', { lo: -2147483648, hi: 2147483647 })
       ).not.toThrow();
     });
+
+    it('rejects a member named __proto__', () => {
+      expect(() => enumType('Bad', { ['__proto__']: 0 })).toThrow(
+        /reserved property/i
+      );
+    });
+  });
+
+  it('preserves member value literal types', () => {
+    // The `const` type parameter keeps members as literal types so union
+    // discriminant narrowing works. Compile-time assertions.
+    expectTypeOf(Color.green).toEqualTypeOf<1>();
+    expectTypeOf<Infer<typeof Color>>().toEqualTypeOf<0 | 1 | 2>();
   });
 });

--- a/test/unit/float.test.ts
+++ b/test/unit/float.test.ts
@@ -20,16 +20,33 @@ describe('float', () => {
       expect(toArray(schema.encode(-2))).toEqual([192, 0, 0, 0]);
     });
 
-    it('throws on non-finite numbers', () => {
-      expect(() => schema.encode(NaN)).toThrow(/finite/i);
-      expect(() => schema.encode(Infinity)).toThrow(/finite/i);
-      expect(() => encodeInvalid(schema, '1')).toThrow(/finite/i);
+    it('throws on non-number input', () => {
+      expect(() => encodeInvalid(schema, '1')).toThrow(/expected number/i);
+    });
+
+    it('encodes IEEE-754 specials to their wire representations', () => {
+      expect(toArray(schema.encode(Infinity))).toEqual([0x7f, 0x80, 0, 0]);
+      expect(toArray(schema.encode(-Infinity))).toEqual([0xff, 0x80, 0, 0]);
+      // NaN encodes as the canonical quiet NaN.
+      expect(toArray(schema.encode(NaN))).toEqual([0x7f, 0xc0, 0, 0]);
+      // -0 keeps its sign bit.
+      expect(toArray(schema.encode(-0))).toEqual([0x80, 0, 0, 0]);
     });
   });
 
+  it('decodes IEEE-754 specials from the wire', () => {
+    expect(schema.decode(bytes([0x7f, 0x80, 0, 0]))).toBe(Infinity);
+    expect(schema.decode(bytes([0xff, 0x80, 0, 0]))).toBe(-Infinity);
+    expect(schema.decode(bytes([0x7f, 0xc0, 0, 0]))).toBeNaN();
+    // A non-canonical (signaling) NaN payload still decodes to NaN.
+    expect(schema.decode(bytes([0x7f, 0x80, 0, 1]))).toBeNaN();
+    expect(Object.is(schema.decode(bytes([0x80, 0, 0, 0])), -0)).toBe(true);
+  });
+
   it('round-trips representable values', () => {
-    for (const value of [0, 1, -1, 0.5, -2, 1234.5]) {
+    for (const value of [0, 1, -1, 0.5, -2, 1234.5, Infinity, -Infinity]) {
       expect(roundTrip(schema, value)).toBe(value);
     }
+    expect(roundTrip(schema, NaN)).toBeNaN();
   });
 });

--- a/test/unit/union.test.ts
+++ b/test/unit/union.test.ts
@@ -127,4 +127,48 @@ describe('union', () => {
       });
     });
   });
+
+  describe('inherited property names', () => {
+    it('rejects a switchKey named __proto__ at construction', () => {
+      expect(() =>
+        union('Bad', {
+          switchOn: AssetType,
+          cases: [caseOf('native', AssetType.native, voidType())],
+          switchKey: '__proto__'
+        })
+      ).toThrow(/'__proto__' is not allowed/);
+    });
+
+    it('rejects an arm payload field named __proto__ at construction', () => {
+      expect(() =>
+        union('Bad', {
+          switchOn: AssetType,
+          cases: [
+            caseOf('credit', AssetType.credit, field('__proto__', int32()))
+          ]
+        })
+      ).toThrow(/'__proto__' is not allowed/);
+    });
+
+    it('detects a missing discriminator that shadows Object.prototype', () => {
+      const Shadow = union('Shadow', {
+        switchOn: AssetType,
+        cases: [caseOf('native', AssetType.native, voidType())],
+        switchKey: 'constructor'
+      });
+      // `'constructor' in value` is true for any plain object; only an
+      // own-property check catches the missing discriminator.
+      expect(() => encodeInvalid(Shadow, {})).toThrow(/discriminator/i);
+    });
+
+    it('detects a missing arm payload that shadows Object.prototype', () => {
+      const Shadow = union('Shadow', {
+        switchOn: AssetType,
+        cases: [caseOf('credit', AssetType.credit, field('toString', int32()))]
+      });
+      expect(() => encodeInvalid(Shadow, { type: 1 })).toThrow(
+        /missing union arm payload/i
+      );
+    });
+  });
 });


### PR DESCRIPTION
# v5-api-fixes

## Preserve enum literal types, support IEEE-754 specials, add importable aliases, harden union/enum field names

API-level fixes from the pre-v5 library review; all four change surface that would be frozen once v5 ships.

- **Enum members keep their literal types** — `enumType` now uses a `const` type
  parameter, so `Infer<typeof ResultType>` is `0 | 1` instead of `number`. This
  makes union discriminant narrowing work and turns invalid encodes like
  `Color.encode(9)` into compile-time errors.
- **float/double accept `NaN` and `±Infinity` on encode** — decode already
  produced them, so legal IEEE-754 wire values previously failed to re-encode
  (the only encode/decode value-domain asymmetry in the library). `NaN` encodes
  as the canonical quiet NaN; payload bits are not preserved.
- **`voidType` and `unionCase` aliases** — `import { void }` / `import { case }`
  are syntax errors, forcing every consumer to alias. The originals remain.
- **Union/enum inherited-name hardening** — `switchKey: '__proto__'` and
  `field('__proto__', …)` rejected at construction; discriminator and arm
  presence checks use `hasOwnProperty` so fields shadowing `Object.prototype`
  (`toString`, `constructor`) are detected when missing. Mirrors the existing
  struct hardening.

Tests cover the IEEE-754 special byte patterns both directions (incl. `-0` and
subnormals), the construction rejections, and compile-time literal-type
assertions.