### PR TITLE
Release pipeline hardening

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,33 +8,34 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # Required for OIDC provenance
+      id-token: write # Required for OIDC trusted publishing / provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        # Version comes from the packageManager field in package.json.
+        uses: pnpm/action-setup@v4
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: true
 
       - name: Update npm for trusted publishing
         run: npm install -g npm@11.5.1
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: Build & Test
-        run: pnpm build && pnpm test
+      - name: Build, Check & Test
+        run: pnpm build && pnpm typecheck && pnpm lint && pnpm test
 
+      # Auth relies on npm Trusted Publishing (OIDC) — no token secret. The
+      # repo must be registered as a trusted publisher for @stellar/js-xdr on
+      # npmjs.com for this to work.
       - name: Publish to npm
-        run: pnpm publish --access public --provenance --no-git-checks --tag ${{ github.event.release.prerelease && 'rc' || 'latest' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run:
+          pnpm publish --access public --provenance --no-git-checks --tag ${{
+          github.event.release.prerelease && 'rc' || 'latest' }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,15 +13,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        # Version comes from the packageManager field in package.json.
-        uses: pnpm/action-setup@v4
-
       - name: Install Node
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install pnpm
+        # Version comes from the packageManager field in package.json.
+        uses: pnpm/action-setup@v4
 
       - name: Update npm for trusted publishing
         run: npm install -g npm@11.5.1
@@ -36,6 +36,6 @@ jobs:
       # repo must be registered as a trusted publisher for @stellar/js-xdr on
       # npmjs.com for this to work.
       - name: Publish to npm
-        run:
+        run: >-
           pnpm publish --access public --provenance --no-git-checks --tag ${{
           github.event.release.prerelease && 'rc' || 'latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        # Version comes from the packageManager field in package.json.
-        uses: pnpm/action-setup@v4
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install pnpm
+        # Version comes from the packageManager field in package.json.
+        uses: pnpm/action-setup@v4
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,25 +8,33 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Use Node.js 22
-        uses: actions/setup-node@v3
-        with:
-          node-version: 22
+        uses: actions/checkout@v4
 
       - name: Install pnpm
+        # Version comes from the packageManager field in package.json.
         uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          version: 10
+          node-version: ${{ matrix.node-version }}
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build All
         run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
 
       - name: Run Tests
         run: pnpm test

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
+  "packageManager": "pnpm@10.33.0",
   "main": "./dist/js-xdr.cjs",
   "module": "./dist/js-xdr.mjs",
   "types": "./dist/js-xdr.d.ts",
@@ -36,13 +37,21 @@
     "fixtures:generate-v4": "node test/fixtures/generate-v4-compat.cjs",
     "fmt": "prettier --write '**/*.{js,ts,json}'",
     "prepare": "husky",
-    "clean": "rm -rf dist"
+    "prepublishOnly": "pnpm build && pnpm typecheck && pnpm lint && pnpm test",
+    "clean": "rm -rf dist lib"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/stellar/js-xdr.git"
   },
-  "keywords": [],
+  "keywords": [
+    "xdr",
+    "rfc4506",
+    "serialization",
+    "codec",
+    "binary",
+    "stellar"
+  ],
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
## Fix the publish pipeline and add missing CI gates

The publish workflow was likely broken (pnpm 9 pinned against `engines >=10`),
and nothing anywhere ran the type checker.

- **`packageManager: pnpm@10.33.0`** — both workflows now let
  `pnpm/action-setup` read it instead of pinning divergent inline versions,
  fixing the publish job's engines mismatch.
- **`prepublishOnly` gate** — `build && typecheck && lint && test` runs on any
  publish, so a stale or untested `dist/` can't ship from a local machine.
- **CI runs `typecheck` and `lint`** — vitest transpiles with esbuild, which
  strips types without checking them; type errors could previously merge green.
  Also adds a Node 22/24 matrix and bumps actions to v4.
- **Publish workflow commits to npm Trusted Publishing** — removes the
  redundant `NPM_TOKEN` (the job already had `id-token: write` +
  `--provenance`). Requires the repo to be registered as a trusted publisher
  for `@stellar/js-xdr` on npmjs.com before the next release.
- Housekeeping: `clean` also removes the stale v4 `lib/` bundle; npm
  `keywords` populated.