### PR TITLE
Schema Introspection api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,20 +8,82 @@ export { XdrError } from './core/error.js';
 export type { XdrType } from './core/xdr-type.js';
 
 export { array } from './types/array.js';
+export type { ArraySchema } from './types/array.js';
 export { bool } from './types/bool.js';
 export { double } from './types/double.js';
 export { enumType } from './types/enum.js';
+export type { EnumMember, EnumName, EnumSchema } from './types/enum.js';
 export { fixedArray } from './types/fixed-array.js';
+export type { FixedArraySchema } from './types/fixed-array.js';
 export { float } from './types/float.js';
 export { int32 } from './types/int32.js';
 export { int64 } from './types/int64.js';
 export { lazy } from './types/lazy.js';
+export type { LazySchema } from './types/lazy.js';
 export { opaque } from './types/opaque.js';
+export type { OpaqueSchema } from './types/opaque.js';
 export { option } from './types/option.js';
+export type { OptionSchema } from './types/option.js';
 export { string } from './types/string.js';
+export type { StringSchema } from './types/string.js';
 export { struct } from './types/struct.js';
+export type { StructSchema } from './types/struct.js';
 export { uint32 } from './types/uint32.js';
 export { uint64 } from './types/uint64.js';
 export { union, case, field } from './types/union.js';
+export type { Field, UnionArm, UnionCase, UnionSchema } from './types/union.js';
 export { varOpaque } from './types/var-opaque.js';
+export type { VarOpaqueSchema } from './types/var-opaque.js';
 export { void } from './types/void.js';
+
+import type { XdrType } from './core/xdr-type.js';
+import type { ArraySchema } from './types/array.js';
+import type { EnumSchema } from './types/enum.js';
+import type { FixedArraySchema } from './types/fixed-array.js';
+import type { LazySchema } from './types/lazy.js';
+import type { OpaqueSchema } from './types/opaque.js';
+import type { OptionSchema } from './types/option.js';
+import type { StringSchema } from './types/string.js';
+import type { StructSchema } from './types/struct.js';
+import type { UnionSchema } from './types/union.js';
+import type { VarOpaqueSchema } from './types/var-opaque.js';
+
+/**
+ * Built-in schema kinds with no extra introspection surface beyond `kind`.
+ */
+export type PrimitiveSchema = XdrType<unknown> & {
+  readonly kind:
+    | 'bool'
+    | 'double'
+    | 'float'
+    | 'int32'
+    | 'int64'
+    | 'uint32'
+    | 'uint64'
+    | 'void';
+};
+
+/**
+ * Closed union of every built-in schema shape, discriminated by `kind`.
+ *
+ * Cast an `XdrType<unknown>` to `AnySchema` once at the entry of a
+ * schema-driven walker; a `switch (schema.kind)` then narrows each branch to
+ * the matching `*Schema` interface with no further casts.
+ *
+ * The union covers only the schemas this package creates. Custom schemas
+ * (subclasses of `BaseType` with their own `kind`) are not part of it, so
+ * walkers over schema trees containing custom types must handle them before
+ * the cast.
+ */
+export type AnySchema =
+  | ArraySchema<unknown>
+  | EnumSchema<string, Record<string, number>>
+  | FixedArraySchema<unknown>
+  | LazySchema<unknown>
+  | OpaqueSchema
+  | OptionSchema<unknown>
+  | PrimitiveSchema
+  | StringSchema
+  | StructSchema<unknown>
+  | UnionSchema<unknown>
+  | VarOpaqueSchema;

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -70,8 +70,21 @@ class ArrayType<T> extends BaseType<T[]> {
 export function array<T extends XdrType<unknown>>(
   element: T,
   maxLength: number
-): XdrType<Infer<T>[]> {
-  return new ArrayType(element, maxLength) as XdrType<Infer<T>[]>;
+): ArraySchema<Infer<T>[]> {
+  return new ArrayType(element, maxLength) as unknown as ArraySchema<
+    Infer<T>[]
+  >;
+}
+
+/**
+ * Public introspection surface of a variable-length array schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'array'`.
+ */
+export interface ArraySchema<T> extends XdrType<T> {
+  readonly kind: 'array';
+  readonly element: XdrType<unknown>;
+  readonly maxLength: number;
 }
 
 /**

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -16,6 +16,7 @@ export type EnumSchema<
   Name extends string,
   Values extends Record<string, number>
 > = XdrType<EnumMember<Values>> & {
+  readonly kind: 'enum';
   readonly name: Name;
   readonly nameByValue: ReadonlyMap<number, EnumName<Values>>;
 } & Values;

--- a/src/types/fixed-array.ts
+++ b/src/types/fixed-array.ts
@@ -50,6 +50,19 @@ class FixedArrayType<T> extends BaseType<T[]> {
 export function fixedArray<T extends XdrType<unknown>>(
   element: T,
   length: number
-): XdrType<Infer<T>[]> {
-  return new FixedArrayType(element, length) as XdrType<Infer<T>[]>;
+): FixedArraySchema<Infer<T>[]> {
+  return new FixedArrayType(element, length) as unknown as FixedArraySchema<
+    Infer<T>[]
+  >;
+}
+
+/**
+ * Public introspection surface of a fixed-length array schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'fixedArray'`.
+ */
+export interface FixedArraySchema<T> extends XdrType<T> {
+  readonly kind: 'fixedArray';
+  readonly element: XdrType<unknown>;
+  readonly length: number;
 }

--- a/src/types/lazy.ts
+++ b/src/types/lazy.ts
@@ -46,6 +46,18 @@ class LazyType<T> extends BaseType<T> {
  */
 export function lazy<T extends XdrType<unknown>>(
   getSchema: () => T
-): XdrType<Infer<T>> {
-  return new LazyType(() => getSchema()) as XdrType<Infer<T>>;
+): LazySchema<Infer<T>> {
+  return new LazyType(() => getSchema()) as unknown as LazySchema<Infer<T>>;
+}
+
+/**
+ * Public introspection surface of a lazy schema reference.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'lazy'`, then call
+ * `getSchema()` to continue walking the resolved schema. Walkers must track
+ * visited schemas: recursive types resolve to themselves.
+ */
+export interface LazySchema<T> extends XdrType<T> {
+  readonly kind: 'lazy';
+  readonly getSchema: () => XdrType<unknown>;
 }

--- a/src/types/opaque.ts
+++ b/src/types/opaque.ts
@@ -10,7 +10,7 @@ import { assertLength, assertUint8Array } from '../core/helpers.js';
 class OpaqueType extends BaseType<Uint8Array> {
   readonly kind = 'opaque';
 
-  constructor(private readonly length: number, name?: string) {
+  constructor(readonly length: number, name?: string) {
     super(name);
     assertLength(length, 'opaque length');
   }
@@ -40,6 +40,16 @@ class OpaqueType extends BaseType<Uint8Array> {
  * format contains the raw bytes followed by zero padding to a 4-byte boundary;
  * no length prefix is encoded.
  */
-export function opaque(length: number, name?: string): XdrType<Uint8Array> {
+export function opaque(length: number, name?: string): OpaqueSchema {
   return new OpaqueType(length, name);
+}
+
+/**
+ * Public introspection surface of a fixed-length opaque schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'opaque'`.
+ */
+export interface OpaqueSchema extends XdrType<Uint8Array> {
+  readonly kind: 'opaque';
+  readonly length: number;
 }

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -42,6 +42,16 @@ class OptionType<T> extends BaseType<T | null> {
  */
 export function option<T extends XdrType<unknown>>(
   element: T
-): XdrType<Infer<T> | null> {
-  return new OptionType(element) as XdrType<Infer<T> | null>;
+): OptionSchema<Infer<T> | null> {
+  return new OptionType(element) as unknown as OptionSchema<Infer<T> | null>;
+}
+
+/**
+ * Public introspection surface of an optional-value schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'option'`.
+ */
+export interface OptionSchema<T> extends XdrType<T> {
+  readonly kind: 'option';
+  readonly element: XdrType<unknown>;
 }

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -12,7 +12,7 @@ import { assertLength } from '../core/helpers.js';
 class StringType extends BaseType<Uint8Array> {
   readonly kind = 'string';
 
-  constructor(private readonly maxLength: number) {
+  constructor(readonly maxLength: number) {
     super();
     assertLength(maxLength, 'string maxLength');
   }
@@ -58,8 +58,18 @@ class StringType extends BaseType<Uint8Array> {
  * const value = new TextDecoder().decode(Name.decode(encoded));
  * ```
  */
-function string_(maxLength: number): XdrType<Uint8Array> {
+function string_(maxLength: number): StringSchema {
   return new StringType(maxLength);
 }
 
 export { string_ as string };
+
+/**
+ * Public introspection surface of a string schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'string'`.
+ */
+export interface StringSchema extends XdrType<Uint8Array> {
+  readonly kind: 'string';
+  readonly maxLength: number;
+}

--- a/src/types/struct.ts
+++ b/src/types/struct.ts
@@ -92,12 +92,24 @@ export function struct<
 >(
   name: Name,
   fields: Shape
-): XdrType<{ readonly [K in keyof Shape]: Infer<Shape[K]> }> & {
+): StructSchema<{ readonly [K in keyof Shape]: Infer<Shape[K]> }> & {
   readonly name: Name;
 } {
-  return new StructType(name, fields) as unknown as XdrType<{
+  return new StructType(name, fields) as unknown as StructSchema<{
     readonly [K in keyof Shape]: Infer<Shape[K]>;
   }> & {
     readonly name: Name;
   };
+}
+
+/**
+ * Public introspection surface of a struct schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'struct'` to walk its
+ * fields generically, for example in a schema-driven JSON converter.
+ */
+export interface StructSchema<T> extends XdrType<T> {
+  readonly kind: 'struct';
+  /** Ordered `[fieldName, fieldSchema]` pairs in wire order. */
+  readonly entries: ReadonlyArray<readonly [string, XdrType<unknown>]>;
 }

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -237,7 +237,7 @@ export function union<
     readonly defaultArm?: DefaultArm;
     readonly switchKey?: SwitchKey;
   }
-): XdrType<UnionValue<Switch, Cases, DefaultArm, SwitchKey>> & {
+): UnionSchema<UnionValue<Switch, Cases, DefaultArm, SwitchKey>> & {
   readonly name: Name;
 } {
   const switchKey = (options.switchKey ?? 'type') as SwitchKey;
@@ -247,9 +247,30 @@ export function union<
     options.cases,
     options.defaultArm,
     switchKey
-  ) as unknown as XdrType<UnionValue<Switch, Cases, DefaultArm, SwitchKey>> & {
+  ) as unknown as UnionSchema<
+    UnionValue<Switch, Cases, DefaultArm, SwitchKey>
+  > & {
     readonly name: Name;
   };
+}
+
+/**
+ * Public introspection surface of a union schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'union'` to walk its
+ * discriminator and arms generically, for example in a schema-driven JSON
+ * converter.
+ */
+export interface UnionSchema<T> extends XdrType<T> {
+  readonly kind: 'union';
+  /** Schema that encodes the discriminant value. */
+  readonly switchOn: XdrType<unknown>;
+  /** Declared discriminator-to-arm mappings. */
+  readonly cases: ReadonlyArray<UnionCase<string, unknown, UnionArm>>;
+  /** Arm used for discriminants with no matching case, if declared. */
+  readonly defaultArm: UnionArm | undefined;
+  /** Property holding the discriminant on JavaScript values. */
+  readonly switchKey: string;
 }
 
 function readUnionArm(

--- a/src/types/var-opaque.ts
+++ b/src/types/var-opaque.ts
@@ -10,7 +10,7 @@ import { assertLength, assertUint8Array } from '../core/helpers.js';
 class VarOpaqueType extends BaseType<Uint8Array> {
   readonly kind = 'varOpaque';
 
-  constructor(private readonly maxLength: number, name?: string) {
+  constructor(readonly maxLength: number, name?: string) {
     super(name);
     assertLength(maxLength, 'varOpaque maxLength');
   }
@@ -46,9 +46,16 @@ class VarOpaqueType extends BaseType<Uint8Array> {
  * Values are `Uint8Array`s with length at most `maxLength`. The wire format is
  * a uint32 byte length, the raw bytes, then zero padding to a 4-byte boundary.
  */
-export function varOpaque(
-  maxLength: number,
-  name?: string
-): XdrType<Uint8Array> {
+export function varOpaque(maxLength: number, name?: string): VarOpaqueSchema {
   return new VarOpaqueType(maxLength, name);
+}
+
+/**
+ * Public introspection surface of a variable-length opaque schema.
+ *
+ * Narrow any `XdrType<unknown>` with `schema.kind === 'varOpaque'`.
+ */
+export interface VarOpaqueSchema extends XdrType<Uint8Array> {
+  readonly kind: 'varOpaque';
+  readonly maxLength: number;
 }

--- a/test/unit/introspection.test.ts
+++ b/test/unit/introspection.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  array,
+  enumType,
+  field,
+  fixedArray,
+  int32,
+  lazy,
+  opaque,
+  option,
+  string,
+  struct,
+  union,
+  case as caseOf,
+  void as voidType
+} from '../../src/index.js';
+import type { AnySchema, UnionSchema, XdrType } from '../../src/index.js';
+
+// A miniature schema-driven walker, the way an external toJson/fromJson
+// implementation would consume this API: one cast to the closed AnySchema
+// union at the entry, after which `switch (kind)` genuinely narrows each
+// branch to its *Schema interface -- no per-branch casts.
+function describeSchema(schema: XdrType<unknown>): unknown {
+  const s = schema as AnySchema;
+  switch (s.kind) {
+    case 'struct':
+      return {
+        struct: s.name,
+        fields: s.entries.map(([key, child]) => [key, describeSchema(child)])
+      };
+    case 'union':
+      return {
+        union: s.name,
+        switchKey: s.switchKey,
+        switchOn: describeSchema(s.switchOn),
+        cases: s.cases.map((c) => c.name),
+        hasDefault: s.defaultArm !== undefined
+      };
+    case 'enum':
+      return { enum: s.name, members: [...s.nameByValue.values()] };
+    case 'array':
+      return { array: describeSchema(s.element), maxLength: s.maxLength };
+    case 'fixedArray':
+      return { fixedArray: describeSchema(s.element), length: s.length };
+    case 'option':
+      return { option: describeSchema(s.element) };
+    case 'lazy':
+      // A real walker must track visited schemas; this fixture's lazy target
+      // is non-recursive so a direct step through is safe here.
+      return { lazy: describeSchema(s.getSchema()) };
+    case 'opaque':
+      return { opaque: s.length };
+    case 'varOpaque':
+    case 'string':
+      return { [s.kind]: s.maxLength };
+    default:
+      return s.kind;
+  }
+}
+
+describe('schema introspection', () => {
+  it('exposes the walker surface for every compound kind', () => {
+    const Hash = opaque(4);
+    const Kind = enumType('Kind', { a: 0, b: 1 });
+    const Entry = struct('Entry', {
+      id: int32(),
+      hash: Hash,
+      tag: option(string(8))
+    });
+    const Payload = union('Payload', {
+      switchOn: Kind,
+      cases: [
+        caseOf('a', 0, voidType()),
+        caseOf(
+          'b',
+          1,
+          field(
+            'entries',
+            array(
+              lazy(() => Entry),
+              10
+            )
+          )
+        )
+      ]
+    });
+    const Fixed = fixedArray(int32(), 2);
+
+    expect(describeSchema(Payload)).toEqual({
+      union: 'Payload',
+      switchKey: 'type',
+      switchOn: { enum: 'Kind', members: ['a', 'b'] },
+      cases: ['a', 'b'],
+      hasDefault: false
+    });
+
+    const kindCase = (Payload as unknown as UnionSchema<unknown>).cases.find(
+      (c) => c.name === 'b'
+    );
+    expect(kindCase && 'schema' in kindCase.arm).toBe(true);
+
+    expect(describeSchema(Entry)).toEqual({
+      struct: 'Entry',
+      fields: [
+        ['id', 'int32'],
+        ['hash', { opaque: 4 }],
+        ['tag', { option: { string: 8 } }]
+      ]
+    });
+
+    expect(describeSchema(Fixed)).toEqual({ fixedArray: 'int32', length: 2 });
+    expect(describeSchema(lazy(() => Hash))).toEqual({ lazy: { opaque: 4 } });
+  });
+
+  it('exposes struct entries and union cases directly off the factory return type', () => {
+    // No casts here: the factory return types themselves carry the surface.
+    const Color = struct('Color', { red: int32(), green: int32() });
+    expect(Color.entries.map(([k]) => k)).toEqual(['red', 'green']);
+
+    const Tagged = union('Tagged', {
+      switchOn: int32(),
+      cases: [caseOf('one', 1, voidType())]
+    });
+    expect(Tagged.switchKey).toBe('type');
+    expect(Tagged.cases.map((c) => c.discriminant)).toEqual([1]);
+    expect(Tagged.defaultArm).toBeUndefined();
+
+    expect(opaque(32).length).toBe(32);
+    expect(string(64).maxLength).toBe(64);
+    expect(array(int32(), 5).maxLength).toBe(5);
+    expect(fixedArray(int32(), 3).length).toBe(3);
+    expect(option(int32()).element.kind).toBe('int32');
+  });
+});


### PR DESCRIPTION
## Export a typed introspection surface so external walkers don't depend on unchecked casts

The stellar-sdk JSON walker (SEP-0051 `toJson`/`fromJson`) currently
re-declares js-xdr's internal shapes as local interfaces and casts into them —
unverified by the compiler, so an internal rename would fail at runtime, not
compile time. This makes the walker surface real, versioned API.

- **One `*Schema` interface per parameterized kind** (`StructSchema`,
  `UnionSchema`, `ArraySchema`, `FixedArraySchema`, `OptionSchema`,
  `LazySchema`, `OpaqueSchema`, `VarOpaqueSchema`, `StringSchema`; `kind:
  'enum'` added to `EnumSchema`), each extending `XdrType<T>` with `kind`
  narrowed to its literal. Factories return these types, so `Color.entries`
  and `Tagged.cases` typecheck with no casts. The exposure mirrors constructor
  inputs, so it adds essentially no new representation commitment.
- **`AnySchema`** — a closed union of all built-in schema shapes. Walkers cast
  once at the entry; `switch (schema.kind)` then genuinely narrows each branch
  (and gives exhaustiveness checking — the compiler catches a missing kind).
  Custom `BaseType` subclasses are documented as outside the closed union.
- `opaque`/`varOpaque`/`string` lengths made `readonly` public (walkers need
  them; previously `private`).
- The test suite includes a miniature schema-driven walker as a compile-time
  proof that the external walker can be written against public API alone.