### PR TITLE
perf(core): avoid per-scalar and per-union-arm allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - `Reader` now snapshots its input length at construction: bytes exposed by
   resizing the backing `ArrayBuffer` after construction are out of bounds and
   read as truncated input.
-- `Reader` rejects input that is not a real typed array with a `TypeError` at
-  construction instead of failing on the first read.
+- `Reader` rejects input that is not a byte-sized typed array with a
+  `TypeError` at construction instead of failing on the first read. A
+  `DataView` or a wider typed array such as `Uint16Array` used to read as the
+  wrong bytes.
 - `Reader` and `Writer` reject a non-integer or negative `maxDepth` with an
   `XdrError` instead of silently disabling the recursion guard.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,82 +3,206 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v5.0.0-rc.1](https://github.com/stellar/js-xdr/compare/v4.0.0...v5.0.0-rc.1)
-
-A complete rewrite of the library. The runtime `xdr.config(...)` schema-definition DSL has been replaced with a set of statically-typed, explicitly-declared schema builders, and the entire source has been migrated from JavaScript to TypeScript. See [MIGRATION.md](./MIGRATION.md) for a step-by-step upgrade guide.
-
-### Breaking Change
-* **Removed the dynamic `config` / `TypeBuilder` DSL.** Schemas are no longer built at runtime by resolving a graph of `Reference`s inside `xdr.config(...)`. Instead, you compose schemas directly from exported builder functions: `array`, `bool`, `double`, `enumType`, `fixedArray`, `float`, `int32`, `int64`, `lazy`, `opaque`, `option`, `string`, `struct`, `uint32`, `uint64`, `union` (composed with the `case` and `field` arm helpers), `varOpaque`, and `void`. Forward/recursive references that the old DSL resolved automatically are now expressed explicitly with `lazy(() => schema)`.
-* **Renamed the encode/decode API.** `toXDR()` / `fromXDR()` → `encode()` / `decode()`. The `format` argument (`'raw' | 'hex' | 'base64'`) has been dropped — `encode` always returns a `Uint8Array` and `decode` always takes one. Callers that relied on hex/base64 strings or `Buffer` output must convert at the boundary.
-* **Updated validation APIs.** `validateXDR(input, format)` is now `validateXdr(bytes, options)` and accepts raw `Uint8Array` bytes only; callers that used hex/base64 validation must convert at the boundary first. The new `validate(value)` method checks whether a JavaScript value can be encoded by the schema.
-* **`encode()` returns `Uint8Array` instead of `Buffer`.**
-* **Renamed the low-level streaming types.** `XdrReader` → `Reader` and `XdrWriter` → `Writer`.
-* **Consolidated the error types.** `XdrReaderError`, `XdrWriterError`, `XdrDefinitionError`, and `XdrNotImplementedDefinitionError` are replaced by a single `XdrError`.
-* **Removed the exported base classes.** `XdrPrimitiveType`, `XdrCompositeType`, and `NestedXdrType` are gone; custom schemas now extend the new `BaseType` or implement the `XdrType<T>` interface.
-* **Renamed/reshaped the numeric types.** `Int`/`UnsignedInt` → `int32`/`uint32` (return JS `number`); `Hyper`/`UnsignedHyper`/`LargeInt` → `int64`/`uint64` (return `bigint`, with range-checked encoding). The `Quadruple` type has been removed (it was already unsupported and threw on use).
-* **`string` is now bytes-only.** `string(maxLength)` reads and writes a `Uint8Array` with no charset handling; v4's `String` accepted UTF-8 JavaScript strings on write and offered a `readString()` helper. Convert text at the boundary with `TextEncoder`/`TextDecoder`. (`opaque`/`varOpaque` are likewise `Uint8Array`, not `Buffer`.)
-* **Renamed and reshaped the array types.** v4's fixed-length `Array` → `fixedArray(element, length)`; its variable-length `VarArray` → `array(element, maxLength)`. Note the flip: `array` is the **variable-length** type in v5 (it was fixed-length in v4), so audit existing call sites.
-* **New package layout.** `main`/`module`/`browser` fields are replaced by an `exports` map exposing dual ESM (`dist/js-xdr.mjs`) and CommonJS (`dist/js-xdr.cjs`) builds plus generated type declarations (`dist/js-xdr.d.ts`). Output is now `dist/` only (the `lib/` build is gone), the package is marked `sideEffects: false`, and Node `>=22` is required.
-
-### Added
-* **First-class TypeScript types.** Schemas carry full type information; `Infer<typeof schema>` yields the encoded/decoded value type, and `struct`/`union`/`enumType` produce strongly-typed object, tagged-union, and named-member types.
-* **`lazy(() => schema)`** builder for defining recursive and forward-referencing schemas.
-* **`BaseType` / `XdrType<T>`** are exported as the base class and interface for all schemas, along with a `DecodeOptions` `{ maxDepth }` option preserved from the prior recursion-depth guard.
-* **`enumType` reserved-name and duplicate-value validation** — throws if a member name collides with a schema property (`name`, `kind`, `encode`, …) or if two members share a wire value.
-* **Schema introspection API.** Every builder now returns a typed schema interface (`StructSchema`, `UnionSchema`, `ArraySchema`, `FixedArraySchema`, `OptionSchema`, `LazySchema`, `OpaqueSchema`, `VarOpaqueSchema`, `StringSchema`, `EnumSchema`) whose `kind` property is narrowed to a literal, plus a closed `AnySchema` union (with `PrimitiveSchema` covering the argument-less kinds). Schema-driven walkers — such as generic JSON converters — can cast once to `AnySchema` and `switch (schema.kind)` with exhaustiveness checking, instead of re-declaring internal shapes and casting. Supporting surface: `enumType` schemas expose `nameByValue` (wire value → member name); `opaque`/`varOpaque`/`string` expose their `length`/`maxLength`; `EnumMember`, `EnumName`, `Field`, `UnionArm`, and `UnionCase` helper types are exported.
-* **`encode(value, { maxDepth })`** — the depth guard also applies to encoding (via the exported `EncodeOptions`), failing with `XdrError` on cyclic values fed to recursive schemas instead of overflowing the call stack.
+## Unreleased
 
 ### Changed
-* **Build chain modernized:** Webpack + Babel → Rollup + esbuild; output is a clean dual ESM/CJS bundle with `.d.ts` emission via `rollup-plugin-dts`.
-* **Test framework replaced:** Mocha + Karma + Sinon + Chai → Vitest; the full unit suite was rewritten in TypeScript (`*.test.ts`).
-* **Linting modernized:** ESLint 8 (airbnb-base config) → ESLint 9 flat config (`eslint.config.mjs`) with `typescript-eslint`; added `pnpm lint` and `pnpm typecheck` scripts.
+
+- Faster encoding and decoding: `Reader` and `Writer` now reuse a single
+  `DataView` for all scalar reads and writes instead of allocating one per
+  value, and union decoding no longer allocates an extra object per arm.
+- `Reader` now snapshots its input length at construction: bytes exposed by
+  resizing the backing `ArrayBuffer` after construction are out of bounds and
+  read as truncated input.
+- `Reader` rejects input that is not a real typed array with a `TypeError` at
+  construction instead of failing on the first read.
+- `Reader` and `Writer` reject a non-integer or negative `maxDepth` with an
+  `XdrError` instead of silently disabling the recursion guard.
+
+### Fixed
+
+- `Reader` now treats input backed by a detached `ArrayBuffer` as empty, so
+  `validateXdr` returns the schema's normal validation result instead of
+  throwing a `TypeError`.
+
+## [v5.0.0-rc.1](https://github.com/stellar/js-xdr/compare/v4.0.0...v5.0.0-rc.1)
+
+A complete rewrite of the library. The runtime `xdr.config(...)`
+schema-definition DSL has been replaced with a set of statically-typed,
+explicitly-declared schema builders, and the entire source has been migrated
+from JavaScript to TypeScript. See [MIGRATION.md](./MIGRATION.md) for a
+step-by-step upgrade guide.
+
+### Breaking Change
+
+- **Removed the dynamic `config` / `TypeBuilder` DSL.** Schemas are no longer
+  built at runtime by resolving a graph of `Reference`s inside
+  `xdr.config(...)`. Instead, you compose schemas directly from exported builder
+  functions: `array`, `bool`, `double`, `enumType`, `fixedArray`, `float`,
+  `int32`, `int64`, `lazy`, `opaque`, `option`, `string`, `struct`, `uint32`,
+  `uint64`, `union` (composed with the `case` and `field` arm helpers),
+  `varOpaque`, and `void`. Forward/recursive references that the old DSL
+  resolved automatically are now expressed explicitly with `lazy(() => schema)`.
+- **Renamed the encode/decode API.** `toXDR()` / `fromXDR()` → `encode()` /
+  `decode()`. The `format` argument (`'raw' | 'hex' | 'base64'`) has been
+  dropped — `encode` always returns a `Uint8Array` and `decode` always takes
+  one. Callers that relied on hex/base64 strings or `Buffer` output must convert
+  at the boundary.
+- **Updated validation APIs.** `validateXDR(input, format)` is now
+  `validateXdr(bytes, options)` and accepts raw `Uint8Array` bytes only; callers
+  that used hex/base64 validation must convert at the boundary first. The new
+  `validate(value)` method checks whether a JavaScript value can be encoded by
+  the schema.
+- **`encode()` returns `Uint8Array` instead of `Buffer`.**
+- **Renamed the low-level streaming types.** `XdrReader` → `Reader` and
+  `XdrWriter` → `Writer`.
+- **Consolidated the error types.** `XdrReaderError`, `XdrWriterError`,
+  `XdrDefinitionError`, and `XdrNotImplementedDefinitionError` are replaced by a
+  single `XdrError`.
+- **Removed the exported base classes.** `XdrPrimitiveType`, `XdrCompositeType`,
+  and `NestedXdrType` are gone; custom schemas now extend the new `BaseType` or
+  implement the `XdrType<T>` interface.
+- **Renamed/reshaped the numeric types.** `Int`/`UnsignedInt` → `int32`/`uint32`
+  (return JS `number`); `Hyper`/`UnsignedHyper`/`LargeInt` → `int64`/`uint64`
+  (return `bigint`, with range-checked encoding). The `Quadruple` type has been
+  removed (it was already unsupported and threw on use).
+- **`string` is now bytes-only.** `string(maxLength)` reads and writes a
+  `Uint8Array` with no charset handling; v4's `String` accepted UTF-8 JavaScript
+  strings on write and offered a `readString()` helper. Convert text at the
+  boundary with `TextEncoder`/`TextDecoder`. (`opaque`/`varOpaque` are likewise
+  `Uint8Array`, not `Buffer`.)
+- **Renamed and reshaped the array types.** v4's fixed-length `Array` →
+  `fixedArray(element, length)`; its variable-length `VarArray` →
+  `array(element, maxLength)`. Note the flip: `array` is the **variable-length**
+  type in v5 (it was fixed-length in v4), so audit existing call sites.
+- **New package layout.** `main`/`module`/`browser` fields are replaced by an
+  `exports` map exposing dual ESM (`dist/js-xdr.mjs`) and CommonJS
+  (`dist/js-xdr.cjs`) builds plus generated type declarations
+  (`dist/js-xdr.d.ts`). Output is now `dist/` only (the `lib/` build is gone),
+  the package is marked `sideEffects: false`, and Node `>=22` is required.
+
+### Added
+
+- **First-class TypeScript types.** Schemas carry full type information;
+  `Infer<typeof schema>` yields the encoded/decoded value type, and
+  `struct`/`union`/`enumType` produce strongly-typed object, tagged-union, and
+  named-member types.
+- **`lazy(() => schema)`** builder for defining recursive and
+  forward-referencing schemas.
+- **`BaseType` / `XdrType<T>`** are exported as the base class and interface for
+  all schemas, along with a `DecodeOptions` `{ maxDepth }` option preserved from
+  the prior recursion-depth guard.
+- **`enumType` reserved-name and duplicate-value validation** — throws if a
+  member name collides with a schema property (`name`, `kind`, `encode`, …) or
+  if two members share a wire value.
+- **Schema introspection API.** Every builder now returns a typed schema
+  interface (`StructSchema`, `UnionSchema`, `ArraySchema`, `FixedArraySchema`,
+  `OptionSchema`, `LazySchema`, `OpaqueSchema`, `VarOpaqueSchema`,
+  `StringSchema`, `EnumSchema`) whose `kind` property is narrowed to a literal,
+  plus a closed `AnySchema` union (with `PrimitiveSchema` covering the
+  argument-less kinds). Schema-driven walkers — such as generic JSON converters
+  — can cast once to `AnySchema` and `switch (schema.kind)` with exhaustiveness
+  checking, instead of re-declaring internal shapes and casting. Supporting
+  surface: `enumType` schemas expose `nameByValue` (wire value → member name);
+  `opaque`/`varOpaque`/`string` expose their `length`/`maxLength`; `EnumMember`,
+  `EnumName`, `Field`, `UnionArm`, and `UnionCase` helper types are exported.
+- **`encode(value, { maxDepth })`** — the depth guard also applies to encoding
+  (via the exported `EncodeOptions`), failing with `XdrError` on cyclic values
+  fed to recursive schemas instead of overflowing the call stack.
+
+### Changed
+
+- **Build chain modernized:** Webpack + Babel → Rollup + esbuild; output is a
+  clean dual ESM/CJS bundle with `.d.ts` emission via `rollup-plugin-dts`.
+- **Test framework replaced:** Mocha + Karma + Sinon + Chai → Vitest; the full
+  unit suite was rewritten in TypeScript (`*.test.ts`).
+- **Linting modernized:** ESLint 8 (airbnb-base config) → ESLint 9 flat config
+  (`eslint.config.mjs`) with `typescript-eslint`; added `pnpm lint` and
+  `pnpm typecheck` scripts.
 
 ## [v4.0.0](https://github.com/stellar/js-xdr/compare/v3.1.2...v4.0.0)
 
 ### Breaking Change
-* Removed [the custom `Buffer.subarray` polyfill](https://github.com/stellar/js-xdr/pull/118) introduced in v3.1.1 to address the issue of it not being usable in the React Native Hermes engine. We recommend using [`@exodus/patch-broken-hermes-typed-arrays`](https://github.com/ExodusMovement/patch-broken-hermes-typed-arrays) as an alternative. If needed, please review and consider manually adding it to your project ([#128](https://github.com/stellar/js-xdr/pull/128)).
+
+- Removed
+  [the custom `Buffer.subarray` polyfill](https://github.com/stellar/js-xdr/pull/118)
+  introduced in v3.1.1 to address the issue of it not being usable in the React
+  Native Hermes engine. We recommend using
+  [`@exodus/patch-broken-hermes-typed-arrays`](https://github.com/ExodusMovement/patch-broken-hermes-typed-arrays)
+  as an alternative. If needed, please review and consider manually adding it to
+  your project ([#128](https://github.com/stellar/js-xdr/pull/128)).
 
 ### Added
-* Added optional `maxDepth` decoding limits for nested recursive types to guard against stack overflows during decode. `Array`, `VarArray`, and `Option` constructors now accept a depth limit, and `Struct.create` / `Union.create` can configure per-type decode depth budgets.
+
+- Added optional `maxDepth` decoding limits for nested recursive types to guard
+  against stack overflows during decode. `Array`, `VarArray`, and `Option`
+  constructors now accept a depth limit, and `Struct.create` / `Union.create`
+  can configure per-type decode depth budgets.
 
 ### Fixed
-* Decoding Array and VarArray now fast fails when the array length exceeds remaining bytes to decode ([#132](https://github.com/stellar/js-xdr/pull/132))
 
-* Fixed silent truncation of bigint values exceeding the range of sized integers (`Hyper`, `UnsignedHyper`, and other `LargeInt` subtypes). Construction, encoding, and multi-part assembly now throw on overflow/underflow instead of silently clamping. `isValid` also validates value range. `sliceBigInt` now returns signed slice values for consistency ([#133](https://github.com/stellar/js-xdr/pull/133)).
+- Decoding Array and VarArray now fast fails when the array length exceeds
+  remaining bytes to decode ([#132](https://github.com/stellar/js-xdr/pull/132))
+
+- Fixed silent truncation of bigint values exceeding the range of sized integers
+  (`Hyper`, `UnsignedHyper`, and other `LargeInt` subtypes). Construction,
+  encoding, and multi-part assembly now throw on overflow/underflow instead of
+  silently clamping. `isValid` also validates value range. `sliceBigInt` now
+  returns signed slice values for consistency
+  ([#133](https://github.com/stellar/js-xdr/pull/133)).
 
 ## [v3.1.2](https://github.com/stellar/js-xdr/compare/v3.1.1...v3.1.2)
 
 ### Fixed
-* Increase robustness of compatibility across multiple `js-xdr` instances in an environment ([#122](https://github.com/stellar/js-xdr/pull/122)).
 
+- Increase robustness of compatibility across multiple `js-xdr` instances in an
+  environment ([#122](https://github.com/stellar/js-xdr/pull/122)).
 
 ## [v3.1.1](https://github.com/stellar/js-xdr/compare/v3.1.0...v3.1.1)
 
 ### Fixed
-* Add compatibility with pre-ES2016 environments (like some React Native JS compilers) by adding a custom `Buffer.subarray` polyfill ([#118](https://github.com/stellar/js-xdr/pull/118)).
 
+- Add compatibility with pre-ES2016 environments (like some React Native JS
+  compilers) by adding a custom `Buffer.subarray` polyfill
+  ([#118](https://github.com/stellar/js-xdr/pull/118)).
 
 ## [v3.1.0](https://github.com/stellar/js-xdr/compare/v3.0.1...v3.1.0)
 
 ### Added
-* The raw, underlying `XdrReader` and `XdrWriter` types are now exposed by the library for reading without consuming the entire stream ([#116](https://github.com/stellar/js-xdr/pull/116)).
+
+- The raw, underlying `XdrReader` and `XdrWriter` types are now exposed by the
+  library for reading without consuming the entire stream
+  ([#116](https://github.com/stellar/js-xdr/pull/116)).
 
 ### Fixed
-* Added additional type checks for passing a bytearray-like object to `XdrReader`s and improves the error with details ([#116](https://github.com/stellar/js-xdr/pull/116)).
 
+- Added additional type checks for passing a bytearray-like object to
+  `XdrReader`s and improves the error with details
+  ([#116](https://github.com/stellar/js-xdr/pull/116)).
 
 ## [v3.0.1](https://github.com/stellar/js-xdr/compare/v3.0.0...v3.0.1)
 
 ### Fixes
-- This package is now being published to `@stellar/js-xdr` on NPM.
-- The versions at `js-xdr` are now considered **deprecated** ([#111](https://github.com/stellar/js-xdr/pull/111)).
-- Misc. dependencies have been upgraded ([#104](https://github.com/stellar/js-xdr/pull/104), [#106](https://github.com/stellar/js-xdr/pull/106), [#107](https://github.com/stellar/js-xdr/pull/107), [#108](https://github.com/stellar/js-xdr/pull/108), [#105](https://github.com/stellar/js-xdr/pull/105)).
 
+- This package is now being published to `@stellar/js-xdr` on NPM.
+- The versions at `js-xdr` are now considered **deprecated**
+  ([#111](https://github.com/stellar/js-xdr/pull/111)).
+- Misc. dependencies have been upgraded
+  ([#104](https://github.com/stellar/js-xdr/pull/104),
+  [#106](https://github.com/stellar/js-xdr/pull/106),
+  [#107](https://github.com/stellar/js-xdr/pull/107),
+  [#108](https://github.com/stellar/js-xdr/pull/108),
+  [#105](https://github.com/stellar/js-xdr/pull/105)).
 
 ## [v3.0.0](https://github.com/stellar/js-xdr/compare/v2.0.0...v3.0.0)
 
 ### Breaking Change
-- Add support for easily encoding integers larger than 32 bits ([#100](https://github.com/stellar/js-xdr/pull/100)). This (partially) breaks the API for creating `Hyper` and `UnsignedHyper` instances. Previously, you would pass `low` and `high` parts to represent the lower and upper 32 bits. Now, you can pass the entire 64-bit value directly as a `bigint` or `string` instance, or as a list of "chunks" like before, e.g.:
+
+- Add support for easily encoding integers larger than 32 bits
+  ([#100](https://github.com/stellar/js-xdr/pull/100)). This (partially) breaks
+  the API for creating `Hyper` and `UnsignedHyper` instances. Previously, you
+  would pass `low` and `high` parts to represent the lower and upper 32 bits.
+  Now, you can pass the entire 64-bit value directly as a `bigint` or `string`
+  instance, or as a list of "chunks" like before, e.g.:
 
 ```diff
 -new Hyper({ low: 1, high: 1 }); // representing (1 << 32) + 1 = 4294967297n
@@ -87,10 +211,10 @@ A complete rewrite of the library. The runtime `xdr.config(...)` schema-definiti
 +new Hyper(1, 1);
 ```
 
-
 ## [v2.0.0](https://github.com/stellar/js-xdr/compare/v1.3.0...v2.0.0)
 
-- Refactor XDR serialization/deserialization logic ([#91](https://github.com/stellar/js-xdr/pull/91)).
+- Refactor XDR serialization/deserialization logic
+  ([#91](https://github.com/stellar/js-xdr/pull/91)).
 - Replace `long` dependency with native `BigInt` arithmetics.
 - Replace `lodash` dependency with built-in Array and Object methods, iterators.
 - Add `buffer` dependency for WebPack browser polyfill.
@@ -99,23 +223,28 @@ A complete rewrite of the library. The runtime `xdr.config(...)` schema-definiti
 - Always check that the entire read buffer is consumed (#32 fixed).
 - Check actual byte size of the string on write (#33 fixed).
 - Fix babel-polyfill build warnings (#34 fixed).
-- Upgrade dependencies to their latest versions ([#92](https://github.com/stellar/js-xdr/pull/92)).
+- Upgrade dependencies to their latest versions
+  ([#92](https://github.com/stellar/js-xdr/pull/92)).
 
 ## [v1.3.0](https://github.com/stellar/js-xdr/compare/v1.2.0...v1.3.0)
 
-- Inline and modernize the `cursor` dependency ([#](https://github.com/stellar/js-xdr/pull/63)).
+- Inline and modernize the `cursor` dependency
+  ([#](https://github.com/stellar/js-xdr/pull/63)).
 
 ## [v1.2.0](https://github.com/stellar/js-xdr/compare/v1.1.4...v1.2.0)
 
-- Add method `validateXDR(input, format = 'raw')` which validates if a given XDR is valid or  not. ([#56](https://github.com/stellar/js-xdr/pull/56)).
+- Add method `validateXDR(input, format = 'raw')` which validates if a given XDR
+  is valid or not. ([#56](https://github.com/stellar/js-xdr/pull/56)).
 
 ## [v1.1.4](https://github.com/stellar/js-xdr/compare/v1.1.3...v1.1.4)
 
-- Remove `core-js` dependency ([#45](https://github.com/stellar/js-xdr/pull/45)).
+- Remove `core-js` dependency
+  ([#45](https://github.com/stellar/js-xdr/pull/45)).
 
 ## [v1.1.3](https://github.com/stellar/js-xdr/compare/v1.1.2...v1.1.3)
 
-- Split out reference class to it's own file to avoid circular import  ([#39](https://github.com/stellar/js-xdr/pull/39)).
+- Split out reference class to it's own file to avoid circular import
+  ([#39](https://github.com/stellar/js-xdr/pull/39)).
 
 ## [v1.1.2](https://github.com/stellar/js-xdr/compare/v1.1.1...v1.1.2)
 

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -1,9 +1,5 @@
 import { XdrError } from './error.js';
 
-export function viewFor(bytes: Uint8Array): DataView {
-  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-}
-
 export function paddingLength(length: number): number {
   return (4 - (length % 4)) % 4;
 }

--- a/src/core/reader.ts
+++ b/src/core/reader.ts
@@ -1,5 +1,5 @@
 import { XdrError } from './error.js';
-import { paddingLength, viewFor } from './helpers.js';
+import { paddingLength } from './helpers.js';
 
 export const DEFAULT_MAX_DEPTH = 200;
 
@@ -9,17 +9,63 @@ export const DEFAULT_MAX_DEPTH = 200;
  * `Reader` advances through one byte sequence, reads big-endian primitive
  * values, verifies zero padding, and tracks nested schema depth. Schema authors
  * use it from `_read`; application code usually calls `schema.decode(bytes)`.
+ *
+ * The reader borrows `bytes` without copying, and its bounds are fixed at
+ * construction. The caller must not mutate, resize, or detach the backing
+ * buffer while the reader is in use.
  */
 export class Reader {
   #offset = 0;
   #depth = 0;
   readonly #maxDepth: number;
+  /**
+   * One view over the whole input, reused by every scalar read. Building a
+   * fresh `DataView` per read (over a fresh `slice()` of the bytes) costs two
+   * allocations per integer, which dominates decoding for union- and
+   * struct-heavy schemas like Stellar's.
+   */
+  readonly #view: DataView;
+  /**
+   * Input length, snapshot from the view. Bounds checks must use this rather
+   * than the live `bytes.length`: over a resizable ArrayBuffer the two can
+   * disagree after a resize, and a check that passes against bytes the view
+   * cannot see turns into a raw RangeError from the scalar read.
+   */
+  readonly #length: number;
 
   constructor(
     private readonly bytes: Uint8Array,
     maxDepth: number = DEFAULT_MAX_DEPTH
   ) {
+    if (maxDepth < 0 || !Number.isInteger(maxDepth)) {
+      throw new XdrError(`invalid maxDepth ${maxDepth}`);
+    }
     this.#maxDepth = maxDepth;
+    // A detached ArrayBuffer rejects DataView construction. Treat it as empty
+    // input (a detached Uint8Array already reports length 0), so reads fail
+    // with the usual XdrError instead of a TypeError here. Only that case:
+    // any other bad input must surface the DataView constructor's TypeError.
+    this.#view = (bytes.buffer as { detached?: boolean } | undefined)?.detached
+      ? new DataView(new ArrayBuffer(0))
+      : new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    this.#length = this.#view.byteLength;
+  }
+
+  /**
+   * Reserve `size` bytes for an in-place scalar read and return the offset to
+   * read them from.
+   */
+  #takeScalar(size: number, path: string): number {
+    if (this.remaining < size) {
+      throw new XdrError(
+        `${path}: incomplete XDR data at offset ${
+          this.#offset
+        }, expected ${size} byte(s)`
+      );
+    }
+    const at = this.#offset;
+    this.#offset += size;
+    return at;
   }
 
   get offset(): number {
@@ -27,12 +73,13 @@ export class Reader {
   }
 
   get remaining(): number {
-    return this.bytes.length - this.#offset;
+    return this.#length - this.#offset;
   }
 
   enter(path: string): void {
     this.#depth += 1;
     if (this.#depth > this.#maxDepth) {
+      this.#depth -= 1;
       throw new XdrError(
         `${path}: max recursion depth ${this.#maxDepth} exceeded`
       );
@@ -63,47 +110,58 @@ export class Reader {
       );
     }
     const result = this.bytes.slice(this.#offset, this.#offset + length);
+    if (result.length !== length) {
+      // The bounds check above uses the length fixed at construction, so a
+      // caller that shrank or detached the input mid-decode gets a short
+      // slice instead of an error. Fail loudly: callers rely on a fixed-length
+      // read returning exactly that many bytes.
+      throw new XdrError(`${path}: input shrank during decode`);
+    }
     this.#offset += length;
     return result;
   }
 
   skipPadding(length: number, path: string): void {
+    if (length < 0 || !Number.isInteger(length)) {
+      throw new XdrError(`${path}: invalid byte length ${length}`);
+    }
     const padding = paddingLength(length);
-    const bytes = this.readBytes(padding, path);
-    for (const byte of bytes) {
-      if (byte !== 0) {
+    if (padding === 0) {
+      return;
+    }
+    const at = this.#takeScalar(padding, path);
+    // Checked in place: the padding bytes are discarded either way, so there
+    // is nothing to copy out.
+    for (let i = 0; i < padding; i++) {
+      if (this.bytes[at + i] !== 0) {
+        // Roll back so a caught error leaves the reader where it was.
+        this.#offset = at;
         throw new XdrError(`${path}: non-zero XDR padding`);
       }
     }
   }
 
   readInt32(path: string): number {
-    const view = viewFor(this.readBytes(4, path));
-    return view.getInt32(0, false);
+    return this.#view.getInt32(this.#takeScalar(4, path), false);
   }
 
   readUint32(path: string): number {
-    const view = viewFor(this.readBytes(4, path));
-    return view.getUint32(0, false);
+    return this.#view.getUint32(this.#takeScalar(4, path), false);
   }
 
   readBigInt64(path: string): bigint {
-    const view = viewFor(this.readBytes(8, path));
-    return view.getBigInt64(0, false);
+    return this.#view.getBigInt64(this.#takeScalar(8, path), false);
   }
 
   readBigUint64(path: string): bigint {
-    const view = viewFor(this.readBytes(8, path));
-    return view.getBigUint64(0, false);
+    return this.#view.getBigUint64(this.#takeScalar(8, path), false);
   }
 
   readFloat32(path: string): number {
-    const view = viewFor(this.readBytes(4, path));
-    return view.getFloat32(0, false);
+    return this.#view.getFloat32(this.#takeScalar(4, path), false);
   }
 
   readFloat64(path: string): number {
-    const view = viewFor(this.readBytes(8, path));
-    return view.getFloat64(0, false);
+    return this.#view.getFloat64(this.#takeScalar(8, path), false);
   }
 }

--- a/src/core/reader.ts
+++ b/src/core/reader.ts
@@ -41,6 +41,14 @@ export class Reader {
       throw new XdrError(`invalid maxDepth ${maxDepth}`);
     }
     this.#maxDepth = maxDepth;
+    // Reject anything that is not a byte-sized typed array. A `DataView` or a
+    // wider typed array carries `buffer`/`byteOffset`/`byteLength`, so scalar
+    // reads would work while `readBytes` indexed by element instead of byte
+    // and returned the wrong bytes. Checked structurally rather than with
+    // `instanceof` so a `Uint8Array` from another realm still works.
+    if (!ArrayBuffer.isView(bytes) || bytes.BYTES_PER_ELEMENT !== 1) {
+      throw new TypeError('Reader expects a Uint8Array');
+    }
     // A detached ArrayBuffer rejects DataView construction. Treat it as empty
     // input (a detached Uint8Array already reports length 0), so reads fail
     // with the usual XdrError instead of a TypeError here. Only that case:

--- a/src/core/writer.ts
+++ b/src/core/writer.ts
@@ -1,5 +1,5 @@
 import { XdrError } from './error.js';
-import { paddingLength, viewFor } from './helpers.js';
+import { paddingLength } from './helpers.js';
 import { DEFAULT_MAX_DEPTH } from './reader.js';
 
 const INITIAL_BUFFER_SIZE = 8192;
@@ -14,11 +14,20 @@ const INITIAL_BUFFER_SIZE = 8192;
  */
 export class Writer {
   #buffer = new Uint8Array(INITIAL_BUFFER_SIZE);
+  /**
+   * View over `#buffer`, reused by every scalar write and rebuilt only when
+   * the buffer grows. Writing through a per-call `Uint8Array` + `DataView`
+   * pair costs two allocations and a copy per integer.
+   */
+  #view = new DataView(this.#buffer.buffer);
   #offset = 0;
   #depth = 0;
   readonly #maxDepth: number;
 
   constructor(maxDepth: number = DEFAULT_MAX_DEPTH) {
+    if (maxDepth < 0 || !Number.isInteger(maxDepth)) {
+      throw new XdrError(`invalid maxDepth ${maxDepth}`);
+    }
     this.#maxDepth = maxDepth;
   }
 
@@ -52,39 +61,48 @@ export class Writer {
   }
 
   writeInt32(value: number): void {
-    const bytes = new Uint8Array(4);
-    viewFor(bytes).setInt32(0, value, false);
-    this.writeBytes(bytes);
+    const offset = this.#prepareScalar(4);
+    this.#view.setInt32(offset, value, false);
+    this.#offset += 4;
   }
 
   writeUint32(value: number): void {
-    const bytes = new Uint8Array(4);
-    viewFor(bytes).setUint32(0, value, false);
-    this.writeBytes(bytes);
+    const offset = this.#prepareScalar(4);
+    this.#view.setUint32(offset, value, false);
+    this.#offset += 4;
   }
 
   writeBigInt64(value: bigint): void {
-    const bytes = new Uint8Array(8);
-    viewFor(bytes).setBigInt64(0, value, false);
-    this.writeBytes(bytes);
+    const offset = this.#prepareScalar(8);
+    this.#view.setBigInt64(offset, value, false);
+    this.#offset += 8;
   }
 
   writeBigUint64(value: bigint): void {
-    const bytes = new Uint8Array(8);
-    viewFor(bytes).setBigUint64(0, value, false);
-    this.writeBytes(bytes);
+    const offset = this.#prepareScalar(8);
+    this.#view.setBigUint64(offset, value, false);
+    this.#offset += 8;
   }
 
   writeFloat32(value: number): void {
-    const bytes = new Uint8Array(4);
-    viewFor(bytes).setFloat32(0, value, false);
-    this.writeBytes(bytes);
+    const offset = this.#prepareScalar(4);
+    this.#view.setFloat32(offset, value, false);
+    this.#offset += 4;
   }
 
   writeFloat64(value: number): void {
-    const bytes = new Uint8Array(8);
-    viewFor(bytes).setFloat64(0, value, false);
-    this.writeBytes(bytes);
+    const offset = this.#prepareScalar(8);
+    this.#view.setFloat64(offset, value, false);
+    this.#offset += 8;
+  }
+
+  /**
+   * Ensure a scalar fits and return its starting offset without advancing.
+   * Callers commit the offset only after the DataView write succeeds.
+   */
+  #prepareScalar(size: number): number {
+    this.#ensureCapacity(size);
+    return this.#offset;
   }
 
   toUint8Array(): Uint8Array {
@@ -105,5 +123,6 @@ export class Writer {
     const nextBuffer = new Uint8Array(nextLength);
     nextBuffer.set(this.#buffer);
     this.#buffer = nextBuffer;
+    this.#view = new DataView(nextBuffer.buffer);
   }
 }

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -309,15 +309,17 @@ function readUnionArm(
   reader: Reader,
   path: string
 ): Record<string, unknown> {
-  const base = { [switchKey]: discriminant };
+  // Built field-by-field rather than as a literal spread onto a `base` object:
+  // the spread allocates a second object for every union read, and unions are
+  // the most common node in a Stellar XDR tree.
+  const result: Record<string, unknown> = {};
+  result[switchKey] = discriminant;
   if (isFieldArm(arm)) {
-    return {
-      ...base,
-      [arm.name]: arm.schema._read(reader, `${path}.${arm.name}`)
-    };
+    result[arm.name] = arm.schema._read(reader, `${path}.${arm.name}`);
+    return result;
   }
   arm._read(reader, path);
-  return base;
+  return result;
 }
 
 function writeUnionArm(

--- a/test/unit/reader.test.ts
+++ b/test/unit/reader.test.ts
@@ -146,10 +146,25 @@ describe('Reader', () => {
     expect(() => reader.readInt32('p')).toThrow(/incomplete/i);
   });
 
-  it('rejects input that is not a typed array at construction', () => {
-    expect(() => new Reader([0, 0, 0, 5] as unknown as Uint8Array)).toThrow(
-      TypeError
-    );
+  it('rejects input that is not a byte-sized typed array', () => {
+    const bad = [
+      [0, 0, 0, 5],
+      new Uint16Array([1, 2]),
+      new DataView(new ArrayBuffer(4))
+    ];
+    for (const input of bad) {
+      expect(() => new Reader(input as unknown as Uint8Array)).toThrow(
+        TypeError
+      );
+    }
+  });
+
+  it('accepts any byte-sized view over a buffer', () => {
+    // Buffer is the common input from Node callers, and a subarray carries a
+    // non-zero byteOffset.
+    expect(new Reader(Buffer.from([0, 0, 0, 5])).readInt32('p')).toBe(5);
+    const window = bytes([9, 9, 0, 0, 0, 5]).subarray(2);
+    expect(new Reader(window).readInt32('p')).toBe(5);
   });
 
   it('validateXdr honors the maxDepth option', () => {

--- a/test/unit/reader.test.ts
+++ b/test/unit/reader.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { Reader, array, int32 } from '../../src/index.js';
 import { bytes } from './_helpers.js';
 
+// Resizable ArrayBuffer is ES2024; the compiler lib is ES2022, so go through
+// a cast to reach the constructor options and `resize`.
+const ResizableArrayBuffer = ArrayBuffer as unknown as new (
+  byteLength: number,
+  options: { maxByteLength: number }
+) => ArrayBuffer & { resize(byteLength: number): void };
+
 describe('Reader', () => {
   it('reads big-endian values and advances the offset', () => {
     const reader = new Reader(bytes([0, 0, 0, 5, 255, 255, 255, 255]));
@@ -38,9 +45,29 @@ describe('Reader', () => {
       const reader = new Reader(bytes([0, 0]));
       expect(() => reader.readBytes(4, 'p')).toThrow(/incomplete/i);
     });
+
+    it('throws rather than returning short data when the input shrinks', () => {
+      const buffer = new ResizableArrayBuffer(32, { maxByteLength: 64 });
+      const reader = new Reader(new Uint8Array(buffer));
+      buffer.resize(8);
+      expect(() => reader.readBytes(32, 'issuer')).toThrow(/shrank/i);
+      expect(reader.offset).toBe(0);
+    });
   });
 
   describe('skipPadding', () => {
+    it('throws on a non-integer or negative length', () => {
+      const reader = new Reader(bytes([0, 0, 0, 0]));
+      expect(() => reader.skipPadding(NaN, 'p')).toThrow(
+        /invalid byte length/i
+      );
+      expect(() => reader.skipPadding(1.5, 'p')).toThrow(
+        /invalid byte length/i
+      );
+      expect(() => reader.skipPadding(-1, 'p')).toThrow(/invalid byte length/i);
+      expect(reader.offset).toBe(0);
+    });
+
     it('consumes the padding bytes for a given length', () => {
       const reader = new Reader(bytes([0, 0, 0]));
       reader.skipPadding(1, 'p');
@@ -50,6 +77,7 @@ describe('Reader', () => {
     it('throws on non-zero padding', () => {
       const reader = new Reader(bytes([0, 9, 0]));
       expect(() => reader.skipPadding(1, 'p')).toThrow(/non-zero/i);
+      expect(reader.offset).toBe(0);
     });
   });
 
@@ -71,6 +99,20 @@ describe('Reader', () => {
       expect(() => reader.enter('p')).toThrow(/max recursion depth/i);
     });
 
+    it('rejects a non-integer or negative maxDepth', () => {
+      expect(() => new Reader(bytes([]), NaN)).toThrow(/invalid maxDepth/i);
+      expect(() => new Reader(bytes([]), 1.5)).toThrow(/invalid maxDepth/i);
+      expect(() => new Reader(bytes([]), -1)).toThrow(/invalid maxDepth/i);
+    });
+
+    it('a failed enter does not consume a level of depth', () => {
+      const reader = new Reader(bytes([]), 1);
+      reader.enter('p');
+      expect(() => reader.enter('p')).toThrow(/max recursion depth/i);
+      reader.exit();
+      expect(() => reader.enter('p')).not.toThrow();
+    });
+
     it('exit frees a level of depth', () => {
       const reader = new Reader(bytes([]), 1);
       reader.enter('p');
@@ -86,6 +128,28 @@ describe('Reader', () => {
       /max recursion depth/i
     );
     expect(nested.decode(wire, { maxDepth: 2 })).toEqual([[5]]);
+  });
+
+  it('treats a detached ArrayBuffer as empty input', () => {
+    const u8 = new Uint8Array([0, 0, 0, 5]);
+    structuredClone(u8.buffer, { transfer: [u8.buffer] });
+    expect(() => new Reader(u8).readInt32('p')).toThrow(/incomplete/i);
+    expect(int32().validateXdr(u8)).toBe(false);
+  });
+
+  it('bounds reads by the length at construction, not a later resize', () => {
+    const buffer = new ResizableArrayBuffer(4, { maxByteLength: 64 });
+    const u8 = new Uint8Array(buffer);
+    const reader = new Reader(u8);
+    buffer.resize(8);
+    expect(reader.readInt32('p')).toBe(0);
+    expect(() => reader.readInt32('p')).toThrow(/incomplete/i);
+  });
+
+  it('rejects input that is not a typed array at construction', () => {
+    expect(() => new Reader([0, 0, 0, 5] as unknown as Uint8Array)).toThrow(
+      TypeError
+    );
   });
 
   it('validateXdr honors the maxDepth option', () => {

--- a/test/unit/writer.test.ts
+++ b/test/unit/writer.test.ts
@@ -3,6 +3,12 @@ import { Writer } from '../../src/index.js';
 import { bytes, toArray } from './_helpers.js';
 
 describe('Writer', () => {
+  it('rejects a non-integer or negative maxDepth', () => {
+    expect(() => new Writer(NaN)).toThrow(/invalid maxDepth/i);
+    expect(() => new Writer(1.5)).toThrow(/invalid maxDepth/i);
+    expect(() => new Writer(-1)).toThrow(/invalid maxDepth/i);
+  });
+
   it('writes big-endian fixed-width integers', () => {
     const writer = new Writer();
     writer.writeInt32(-1);
@@ -49,6 +55,56 @@ describe('Writer', () => {
     expect(output).toHaveLength(payload.length);
     expect(output[0]).toBe(1);
     expect(output[output.length - 1]).toBe(255);
+  });
+
+  it('keeps writing scalars correctly across buffer growth', () => {
+    // The initial buffer holds 8192 bytes, so this crosses several growth
+    // steps. Scalar writes go through a cached DataView, and that view has to
+    // be replaced when the buffer is reallocated.
+    const count = 5000;
+    const writer = new Writer();
+    for (let i = 0; i < count; i++) {
+      writer.writeUint32(i);
+    }
+
+    const output = writer.toUint8Array();
+    expect(output).toHaveLength(count * 4);
+
+    const view = new DataView(
+      output.buffer,
+      output.byteOffset,
+      output.byteLength
+    );
+    for (let i = 0; i < count; i++) {
+      expect(view.getUint32(i * 4, false)).toBe(i);
+    }
+  });
+
+  it('keeps writing scalars correctly when growth is triggered mid-value', () => {
+    // Fill to one byte short of the boundary so the next 8-byte scalar
+    // straddles the reallocation.
+    const writer = new Writer();
+    writer.writeBytes(bytes(new Array(8188).fill(7)));
+    writer.writeBigUint64(0xdead_beef_cafe_baben);
+
+    const output = writer.toUint8Array();
+    expect(output).toHaveLength(8188 + 8);
+    const view = new DataView(
+      output.buffer,
+      output.byteOffset,
+      output.byteLength
+    );
+    expect(view.getBigUint64(8188, false)).toBe(0xdead_beef_cafe_baben);
+  });
+
+  it('does not advance after a scalar write fails', () => {
+    const writer = new Writer();
+    expect(() => writer.writeBigInt64(1 as unknown as bigint)).toThrow(
+      TypeError
+    );
+
+    writer.writeUint32(7);
+    expect(toArray(writer.toUint8Array())).toEqual([0, 0, 0, 7]);
   });
 
   it('pads to the next 4-byte boundary based on length', () => {


### PR DESCRIPTION
## What

`Reader` and `Writer` now keep one `DataView` over their buffer for the life of the operation. Before, every scalar read built a fresh `DataView` over a fresh `slice()` of the input, and every scalar write built a fresh view over the output. Union decoding also dropped the wrapper object it allocated per arm. Encoded bytes and decoded values are unchanged.

The rest of the diff is correctness work that the shared view either required or made cheap:

- `Reader` fixes its bounds at construction and checks every read against that length. Growing the backing buffer after construction can no longer push a read past the end of the view.
- The detached-`ArrayBuffer` case is now an explicit `detached` check instead of a bare `catch` around the `DataView` constructor. Input that is not a typed array throws a `TypeError` at construction instead of a confusing `RangeError` on the first read.
- `readBytes` throws if the slice it took is shorter than requested, so a fixed-length type can never hand back fewer bytes than its schema declares.
- `skipPadding` validates its length again. It lost that check when it stopped routing through `readBytes`.
- `Reader` and `Writer` reject a non-integer or negative `maxDepth` instead of silently disabling the recursion guard. `1 > NaN` is false, so `maxDepth: NaN` used to turn the guard off.
- `Reader.enter` rolls back the depth counter before throwing, matching `Writer.enter`.

The class docs now state the ownership contract: the reader borrows the input without copying, and the caller must not mutate, resize, or detach the backing buffer while the reader is in use. Decoded byte values are still copies, so they never alias the caller's buffer.

## Why

Allocation dominated the old hot path. Reading one `int32` cost two allocations, a `slice` of the bytes and a `DataView` over that slice. Stellar's schemas are mostly scalars, so a single transaction envelope paid that cost hundreds of times. Sharing one view removes both allocations per scalar and leaves the read itself.

Measured on a Stellar-shaped schema (nested structs, a union with a void arm and a payload arm, fixed opaques, mixed 32- and 64-bit scalars, and a variable memo) on Node 24. Times are per operation, averaged over two runs:

| payload | decode before | decode after | encode before | encode after |
| --- | --- | --- | --- | --- |
| 1 op, no memo (84 B) | 2.6 µs | 0.43 µs (6.0x) | 3.0 µs | 0.92 µs (3.3x) |
| 20 ops, 256 B memo (1.9 KB) | 34 µs | 6.6 µs (5.2x) | 33 µs | 8.0 µs (4.1x) |
| 100 ops, 4 KB memo (12 KB) | 160 µs | 31 µs (5.2x) | 167 µs | 32 µs (5.2x) |
| 1 op, 512 KB memo (512 KB) | 19 µs | 17 µs (1.1x) | 50 µs | 44 µs (1.1x) |

Payloads dominated by one large opaque gain the least, which is expected. That path was already a single copy with almost no scalar reads, so there was little allocation to remove.
