### PR TITLE
fix(array): reject zero-width array elements when encoding or decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+* Encoding or decoding a non-empty `array` or `fixedArray` value now throws `XdrError` when the element type encodes to zero bytes, such as `void`, `opaque(0)`, or a struct whose fields are all of those. Every element must consume at least one byte, otherwise the wire-supplied element count is decoupled from the encoded size; the error names the offending element type. An empty value of such an array still round-trips.
+
 ## [v5.0.0-rc.1](https://github.com/stellar/js-xdr/compare/v4.0.0...v5.0.0-rc.1)
 
 A complete rewrite of the library. The runtime `xdr.config(...)` schema-definition DSL has been replaced with a set of statically-typed, explicitly-declared schema builders, and the entire source has been migrated from JavaScript to TypeScript. See [MIGRATION.md](./MIGRATION.md) for a step-by-step upgrade guide.

--- a/src/core/writer.ts
+++ b/src/core/writer.ts
@@ -22,6 +22,10 @@ export class Writer {
     this.#maxDepth = maxDepth;
   }
 
+  get offset(): number {
+    return this.#offset;
+  }
+
   enter(path: string): void {
     this.#depth += 1;
     if (this.#depth > this.#maxDepth) {

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -28,12 +28,10 @@ class ArrayType<T> extends BaseType<T[]> {
           `${path}: array length ${length} exceeds maximum ${this.maxLength}`
         );
       }
-      // Defensive guard: the declared element count must not exceed the number
-      // of bytes remaining. This bounds the decode loop for zero-width element
-      // schemas (void, opaque(0), empty struct), where element reads do not
-      // advance the reader and could otherwise loop/allocate unbounded.
-      // For non-zero-width elements, `readBytes` still enforces exact byte
-      // availability during element decoding.
+      // Every element consumes at least one byte (`readArray` rejects any
+      // element that does not, at the first one). A count above the bytes
+      // remaining can therefore never be satisfied, so fail before decoding
+      // any elements.
       if (length > reader.remaining) {
         throw new XdrError(
           `${path}: array length ${length} exceeds remaining ${reader.remaining} byte(s)`
@@ -106,7 +104,21 @@ export function readArray<T>(
 ): T[] {
   const values: T[] = [];
   for (let i = 0; i < length; i += 1) {
-    values.push(element._read(reader, `${path}[${i}]`));
+    const before = reader.offset;
+    const value = element._read(reader, `${path}[${i}]`);
+    // Every element must consume input. Otherwise the element count alone
+    // decides how much memory this loop allocates, and `length` comes off
+    // the wire. This rejects any element type that encodes to zero bytes:
+    // `void`, `opaque(0)`, a struct whose fields are all of those, or a
+    // custom `XdrType` that reads nothing.
+    if (reader.offset === before) {
+      throw new XdrError(
+        `${path}[${i}]: element type '${
+          element.name ?? element.kind
+        }' consumed no input; an array element must encode to at least one byte`
+      );
+    }
+    values.push(value);
   }
   return values;
 }
@@ -125,7 +137,17 @@ export function writeArray<T>(
 ): void {
   let i = 0;
   for (const value of values) {
+    const before = writer.offset;
     element._write(value, writer, `${path}[${i}]`);
+    // The mirror of the check in `readArray`. Without it an array of a
+    // zero-width element type would encode to bytes that cannot decode back.
+    if (writer.offset === before) {
+      throw new XdrError(
+        `${path}[${i}]: element type '${
+          element.name ?? element.kind
+        }' encoded to zero bytes; an array element must encode to at least one byte`
+      );
+    }
     i += 1;
   }
 }

--- a/src/types/fixed-array.ts
+++ b/src/types/fixed-array.ts
@@ -23,10 +23,10 @@ class FixedArrayType<T> extends BaseType<T[]> {
   _read(reader: Reader, path: string): T[] {
     reader.enter(path);
     try {
-      // Same guard as `array`: a schema-declared count beyond the remaining
-      // input cannot decode, and for zero-width element schemas (void,
-      // opaque(0), empty struct) the element loop would otherwise not be
-      // bounded by input size at all.
+      // The length is schema-declared rather than wire-supplied, but the
+      // same fail-fast as `array` applies: every element consumes at least
+      // one byte, so a length above the bytes remaining can never be
+      // satisfied.
       if (this.length > reader.remaining) {
         throw new XdrError(
           `${path}: array length ${this.length} exceeds remaining ${reader.remaining} byte(s)`

--- a/test/unit/array.test.ts
+++ b/test/unit/array.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { array, int32, void as voidType, XdrError } from '../../src/index.js';
+import {
+  array,
+  BaseType,
+  fixedArray,
+  int32,
+  lazy,
+  opaque,
+  struct,
+  void as voidType,
+  XdrError,
+  type XdrType
+} from '../../src/index.js';
 import { bytes, toArray, roundTrip, encodeInvalid } from './_helpers.js';
 
 // The documented unbounded idiom array(elem, UNBOUNDED_MAX_LENGTH).
@@ -43,41 +54,203 @@ describe('array (variable-length)', () => {
     });
 
     it('rejects a declared element count larger than the remaining input', () => {
-      // Declares 10 elements but only 4 element bytes follow: the count cannot
-      // be backed by the input, so fail fast before the element loop.
+      // Declares 10 elements but only 4 bytes follow. Every element consumes
+      // at least one byte, so the count is rejected before any element reads.
       const wide = array(int32(), 100);
       const input = bytes([0, 0, 0, 10, 0, 0, 0, 1]);
       expect(() => wide.decode(input)).toThrow(XdrError);
       expect(() => wide.decode(input)).toThrow(/exceeds remaining/i);
     });
 
-    it('does not loop or allocate unbounded for a huge count of zero-width elements', () => {
-      // Regression for the element-count DoS: array(void, MAX) declaring
-      // 0xFFFFFFFF elements from a 4-byte input must fail fast with an
-      // XdrError, not spin/OOM or throw a native RangeError.
-      const voidArray = array(voidType(), UNBOUNDED_MAX_LENGTH);
+    it('still rejects a huge count of int32 elements', () => {
+      // The element count is wire-supplied, so it is checked against the
+      // remaining byte count before any element is decoded.
+      const wide = array(int32(), UNBOUNDED_MAX_LENGTH);
       const input = bytes([0xff, 0xff, 0xff, 0xff]);
 
       let caught: unknown;
       try {
-        voidArray.decode(input);
+        wide.decode(input);
       } catch (e) {
         caught = e;
       }
       expect(caught).toBeInstanceOf(XdrError);
       expect(caught).not.toBeInstanceOf(RangeError);
     });
-
-    it('still decodes a zero-width-element array whose count fits the input', () => {
-      // A genuine (if degenerate) zero-width array round-trips: length 0 needs
-      // no element bytes.
-      const voidArray = array(voidType(), 8);
-      expect(voidArray.decode(bytes([0, 0, 0, 0]))).toEqual([]);
-      expect(toArray(voidArray.encode([]))).toEqual([0, 0, 0, 0]);
-    });
   });
 
   it('round-trips element values', () => {
     expect(roundTrip(schema, [10, 20, 30])).toEqual([10, 20, 30]);
+  });
+
+  describe('zero-width element types', () => {
+    // An element that encodes to nothing decouples the element count from the
+    // encoded size, so the count alone would decide how much memory a decode
+    // allocates. RFC 4506 cannot express such an array except through a
+    // struct of `void` members. `readArray` and `writeArray` require every
+    // element to move the offset, so any non-empty value of such an array is
+    // rejected with an error naming the element type.
+
+    it('rejects void as an element type on first use', () => {
+      const voids = array(voidType(), 8);
+      expect(() => voids.encode([undefined])).toThrow(XdrError);
+      expect(() => voids.encode([undefined])).toThrow(
+        /element type 'void' encoded to zero bytes/i
+      );
+      expect(() => voids.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toThrow(
+        /element type 'void' consumed no input/i
+      );
+    });
+
+    it('rejects a struct whose fields are all void, naming the struct', () => {
+      const empty = struct('Empty', { a: voidType(), b: voidType() });
+      expect(() =>
+        array(empty, 8).encode([{ a: undefined, b: undefined }])
+      ).toThrow(/element type 'Empty' encoded to zero bytes/i);
+    });
+
+    it('rejects zero-length opaque and nested zero-width arrays', () => {
+      expect(() => array(opaque(0), 8).encode([bytes([])])).toThrow(
+        /encoded to zero bytes/i
+      );
+      expect(() => array(fixedArray(int32(), 0), 8).encode([[]])).toThrow(
+        /encoded to zero bytes/i
+      );
+    });
+
+    it('accepts any element type that consumes input', () => {
+      expect(roundTrip(array(int32(), 8), [1, 2])).toEqual([1, 2]);
+      // A void field does not make the struct zero-width as long as another
+      // field consumes input.
+      expect(
+        roundTrip(array(struct('S', { a: voidType(), b: int32() }), 8), [
+          { a: undefined, b: 5 }
+        ])
+      ).toEqual([{ a: undefined, b: 5 }]);
+    });
+
+    it('accepts a lazy element type that resolves to a real schema', () => {
+      const lazyInt = array(
+        lazy(() => int32()),
+        8
+      );
+      expect(roundTrip(lazyInt, [1, 2])).toEqual([1, 2]);
+    });
+  });
+
+  describe('zero-width element types behind lazy and custom schemas', () => {
+    // The runtime checks read the offset, not the schema, so they also cover
+    // element types whose zero width is not visible in the schema structure:
+    // behind `lazy` or inside a custom `XdrType`.
+    //
+    // A count of two followed by eight bytes: enough input to satisfy the
+    // count, so a decode failure can only come from an element consuming
+    // none of it.
+    const COUNTED = bytes([0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+    it('rejects an unsatisfiable count before decoding any element', () => {
+      // uint32 100000 with no element bytes: every element consumes at least
+      // one byte, so the count is rejected without allocating anything.
+      const lazyVoid = array(
+        lazy(() => voidType()),
+        UNBOUNDED_MAX_LENGTH
+      );
+      expect(() => lazyVoid.decode(bytes([0, 1, 134, 160]))).toThrow(
+        /exceeds remaining/i
+      );
+    });
+
+    it('rejects a zero-width schema behind a lazy element', () => {
+      const lazyVoid = array(
+        lazy(() => voidType()),
+        UNBOUNDED_MAX_LENGTH
+      );
+      expect(() => lazyVoid.decode(COUNTED)).toThrow(/consumed no input/i);
+      expect(() => lazyVoid.encode([undefined])).toThrow(
+        /encoded to zero bytes/i
+      );
+    });
+
+    it('rejects a zero-width schema behind a lazy struct field', () => {
+      // The zero width is a level down: the struct itself consumes nothing
+      // because its only field does.
+      const hidden = struct('Hidden', { a: lazy(() => voidType()) });
+      const hiddenArray = array(hidden, UNBOUNDED_MAX_LENGTH);
+      expect(() => hiddenArray.decode(COUNTED)).toThrow(/consumed no input/i);
+      expect(() => hiddenArray.encode([{ a: undefined }])).toThrow(
+        /encoded to zero bytes/i
+      );
+    });
+
+    it('rejects a zero-width schema behind a long lazy chain', () => {
+      // Deeply wrapped but still inside the decoder's depth limit; the
+      // offset check works at any depth.
+      let chain: XdrType<unknown> = voidType();
+      for (let i = 0; i < 150; i += 1) {
+        const inner = chain;
+        chain = lazy(() => inner);
+      }
+      expect(() => array(chain, UNBOUNDED_MAX_LENGTH).decode(COUNTED)).toThrow(
+        /consumed no input/i
+      );
+    });
+
+    it('rejects a custom XdrType that reads and writes nothing', () => {
+      class Nothing extends BaseType<Record<string, never>> {
+        readonly kind = 'nothing';
+        _read(): Record<string, never> {
+          return {};
+        }
+        _write(): void {}
+      }
+      const customArray = array(
+        new Nothing() as unknown as XdrType<Record<string, never>>,
+        UNBOUNDED_MAX_LENGTH
+      );
+      expect(() => customArray.decode(COUNTED)).toThrow(/consumed no input/i);
+      expect(() => customArray.encode([{}])).toThrow(/encoded to zero bytes/i);
+    });
+
+    it('rejects a lazy element whose target becomes zero-width later', () => {
+      // Nothing is cached, so a callback that changes what it returns is
+      // re-checked on every use rather than trusted after the first.
+      let target: XdrType<unknown> = int32();
+      const mutable = array(
+        lazy(() => target),
+        UNBOUNDED_MAX_LENGTH
+      );
+      expect(mutable.decode(bytes([0, 0, 0, 1, 0, 0, 0, 7]))).toEqual([7]);
+      target = voidType();
+      expect(() => mutable.decode(COUNTED)).toThrow(/consumed no input/i);
+    });
+
+    it('leaves arrays of byte-backed elements alone', () => {
+      expect(roundTrip(array(int32(), 8), [1, 2, 3])).toEqual([1, 2, 3]);
+      expect(
+        roundTrip(
+          array(
+            lazy(() => int32()),
+            8
+          ),
+          [4, 5]
+        )
+      ).toEqual([4, 5]);
+    });
+
+    it('accepts an empty array of a zero-width element type', () => {
+      // The runtime check runs per element, so a count of zero never reaches
+      // it. Nothing is allocated, and encode and decode agree, so the empty
+      // value round-trips while any non-empty one is rejected.
+      const lazyVoid = array(
+        lazy(() => voidType()),
+        UNBOUNDED_MAX_LENGTH
+      );
+      expect(toArray(lazyVoid.encode([]))).toEqual([0, 0, 0, 0]);
+      expect(lazyVoid.decode(bytes([0, 0, 0, 0]))).toEqual([]);
+      expect(lazyVoid.validateXdr(bytes([0, 0, 0, 0]))).toBe(true);
+      expect(() => lazyVoid.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toThrow(
+        /consumed no input/i
+      );
+    });
   });
 });

--- a/test/unit/fixed-array.test.ts
+++ b/test/unit/fixed-array.test.ts
@@ -43,17 +43,19 @@ describe('fixedArray (fixed-length)', () => {
     expect(roundTrip(schema, [10, 20, 30])).toEqual([10, 20, 30]);
   });
 
-  it('does not loop or allocate unbounded for a huge zero-width-element length', () => {
-    // Same guard as `array`: a schema-declared count beyond the remaining
-    // input fails fast with an XdrError instead of spinning the element loop.
-    const voidArray = fixedArray(voidType(), 4294967295);
-    let caught: unknown;
-    try {
-      voidArray.decode(bytes([]));
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(XdrError);
-    expect((caught as Error).message).toMatch(/exceeds remaining/i);
+  it('rejects a zero-width element type on first use', () => {
+    // The length is schema-declared rather than wire-supplied, but a fixed
+    // array of a zero-width type is itself zero-width, so it would multiply
+    // whatever count an enclosing array declares. Every element must move
+    // the offset, which rejects the first element from either direction.
+    const voids = fixedArray(voidType(), 3);
+    const value = [undefined, undefined, undefined];
+    expect(() => voids.encode(value)).toThrow(XdrError);
+    expect(() => voids.encode(value)).toThrow(
+      /element type 'void' encoded to zero bytes/i
+    );
+    expect(() => voids.decode(bytes([0, 0, 0, 0]))).toThrow(
+      /element type 'void' consumed no input/i
+    );
   });
 });


### PR DESCRIPTION
## What

Arrays now reject element types that encode to zero bytes (`void`, `opaque(0)`, a struct whose fields are all of those) at runtime: `readArray` and `writeArray` require every element to move the reader or writer offset, and throw an `XdrError` naming the offending element type when one does not. A count-versus-remaining-bytes fail-fast in `array` and `fixedArray` decode rejects unsatisfiable wire counts before any element work, and `Writer` gains a public `offset` getter to support the write-side check. Empty values of such arrays still round-trip.

## Why

A zero-width element decouples an array's wire-supplied element count from its encoded size, so the count alone would decide how much memory a decode allocates, and the write side could produce bytes that cannot decode back. Checking the offset at runtime covers every case uniformly, including zero-width types hidden behind `lazy` or inside a custom `XdrType` that no static schema inspection can see, which keeps the mechanism small and makes the resulting error self-explanatory.