### PR TITLE
fix(reader): copy decoded bytes when input is a Buffer subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
-* **`decode` returns independent copies for Node `Buffer` inputs.** `Buffer.prototype.slice` returns a view rather than a copy, so `opaque`/`varOpaque`/`string` values decoded from a `Buffer` aliased the caller's input and could expose Node's shared `Buffer` pool. `Reader` now normalizes its input so decoded byte values never share memory with the input.
+* **`decode` returns independent copies for Node `Buffer` inputs.** `Buffer.prototype.slice` returns a view rather than a copy, so `opaque`/`varOpaque`/`string` values decoded from a `Buffer` aliased the caller's input and could expose Node's shared `Buffer` pool. `Reader` now normalizes its input so decoded byte values never share memory with the input ([#152](https://github.com/stellar/js-xdr/pull/152)).
 
 ## [v5.0.0-rc.1](https://github.com/stellar/js-xdr/compare/v4.0.0...v5.0.0-rc.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+* **`decode` returns independent copies for Node `Buffer` inputs.** `Buffer.prototype.slice` returns a view rather than a copy, so `opaque`/`varOpaque`/`string` values decoded from a `Buffer` aliased the caller's input and could expose Node's shared `Buffer` pool. `Reader` now normalizes its input so decoded byte values never share memory with the input.
+
 ## [v5.0.0-rc.1](https://github.com/stellar/js-xdr/compare/v4.0.0...v5.0.0-rc.1)
 
 A complete rewrite of the library. The runtime `xdr.config(...)` schema-definition DSL has been replaced with a set of statically-typed, explicitly-declared schema builders, and the entire source has been migrated from JavaScript to TypeScript. See [MIGRATION.md](./MIGRATION.md) for a step-by-step upgrade guide.

--- a/src/core/reader.ts
+++ b/src/core/reader.ts
@@ -14,11 +14,25 @@ export class Reader {
   #offset = 0;
   #depth = 0;
   readonly #maxDepth: number;
+  private readonly bytes: Uint8Array;
 
-  constructor(
-    private readonly bytes: Uint8Array,
-    maxDepth: number = DEFAULT_MAX_DEPTH
-  ) {
+  constructor(bytes: Uint8Array, maxDepth: number = DEFAULT_MAX_DEPTH) {
+    // Re-wrap subclassed inputs as a plain Uint8Array so `slice` in readBytes
+    // always copies. Buffer (and any other subclass) overrides `slice` to
+    // return a view. The prototype-identity check (not `constructor`, which a
+    // subclass can shadow) is a fast path for the common plain-Uint8Array
+    // input; the prototype determines which `slice` runs (an own `slice`
+    // property planted on a plain instance is the caller sabotaging their
+    // own input, same as before this normalization existed). The
+    // zero-length guard keeps a view over a detached ArrayBuffer working as
+    // before (it reports byteLength 0; constructing over its buffer would
+    // throw TypeError and change validateXdr's observable behavior).
+    this.bytes =
+      Object.getPrototypeOf(bytes) === Uint8Array.prototype
+        ? bytes
+        : bytes.byteLength === 0
+        ? new Uint8Array(0)
+        : new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     this.#maxDepth = maxDepth;
   }
 

--- a/test/unit/reader.test.ts
+++ b/test/unit/reader.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { Reader, array, int32 } from '../../src/index.js';
+import {
+  Reader,
+  XdrError,
+  array,
+  int32,
+  opaque,
+  string,
+  struct,
+  varOpaque,
+  voidType
+} from '../../src/index.js';
 import { bytes } from './_helpers.js';
 
 describe('Reader', () => {
@@ -37,6 +47,19 @@ describe('Reader', () => {
     it('throws when there is not enough data', () => {
       const reader = new Reader(bytes([0, 0]));
       expect(() => reader.readBytes(4, 'p')).toThrow(/incomplete/i);
+    });
+
+    it('returns an exact-size copy for a Buffer input', () => {
+      const input = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+      const reader = new Reader(input);
+      const out = reader.readBytes(4, 'p');
+
+      expect(Array.from(out)).toEqual([1, 2, 3, 4]);
+      expect(out.buffer).not.toBe(input.buffer);
+      expect(out.buffer.byteLength).toBe(out.byteLength);
+
+      input.fill(0);
+      expect(Array.from(out)).toEqual([1, 2, 3, 4]);
     });
   });
 
@@ -93,5 +116,161 @@ describe('Reader', () => {
     const wire = bytes([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 5]);
     expect(nested.validateXdr(wire, { maxDepth: 1 })).toBe(false);
     expect(nested.validateXdr(wire, { maxDepth: 2 })).toBe(true);
+  });
+
+  // Reader normalizes its input to a plain Uint8Array, so `slice` in
+  // readBytes always performs a genuine copy — even when the caller passes a
+  // Node Buffer, whose overridden `slice` returns an aliasing view. These
+  // tests pin the fixed invariant: decoded byte values never alias the
+  // caller's input and never expose an over-wide backing ArrayBuffer (e.g.
+  // Node's Buffer pool).
+  describe('copies bytes out of subclassed inputs (Buffer et al.)', () => {
+    it('varOpaque decoded from a Buffer is an independent copy', () => {
+      const schema = varOpaque(1024);
+      const wire = Buffer.from([0, 0, 0, 4, 0xaa, 0xbb, 0xcc, 0xdd]);
+      const decoded = schema.decode(wire);
+
+      expect(Array.from(decoded)).toEqual([0xaa, 0xbb, 0xcc, 0xdd]);
+      expect(decoded.buffer).not.toBe(wire.buffer);
+
+      // Mutating the input after decode must not change the decoded value.
+      wire.fill(0, 4, 8);
+      expect(Array.from(decoded)).toEqual([0xaa, 0xbb, 0xcc, 0xdd]);
+
+      // Mutating the decoded value must not change the input.
+      decoded[0] = 0xff;
+      expect(wire[4]).toBe(0);
+    });
+
+    it('pool-backed Buffer input yields an exact-size backing buffer', () => {
+      const schema = varOpaque(1024);
+      // seq: length prefix 4, payload [1,2,3,4]
+      const b64 = Buffer.from([0, 0, 0, 4, 1, 2, 3, 4]).toString('base64');
+      // Buffer.from(b64) draws from Node's shared 8 KiB allocation pool.
+      const wire = Buffer.from(b64, 'base64');
+      const decoded = schema.decode(wire);
+
+      expect(Array.from(decoded)).toEqual([1, 2, 3, 4]);
+      // Exact-size buffer: no pool exposure via decoded.buffer.
+      expect(decoded.buffer.byteLength).toBe(decoded.byteLength);
+    });
+
+    it('control: plain Uint8Array input still returns an independent copy', () => {
+      const schema = varOpaque(1024);
+      const wire = new Uint8Array([0, 0, 0, 4, 0xaa, 0xbb, 0xcc, 0xdd]);
+      const decoded = schema.decode(wire);
+
+      expect(decoded.buffer).not.toBe(wire.buffer);
+      wire.fill(0, 4, 8);
+      expect(Array.from(decoded)).toEqual([0xaa, 0xbb, 0xcc, 0xdd]);
+    });
+
+    it('opaque and string fields in a struct decoded from a Buffer are copies', () => {
+      const schema = struct('S', {
+        fixed: opaque(4),
+        text: string(16)
+      });
+      const wire = Buffer.from(
+        schema.encode({
+          fixed: new Uint8Array([9, 8, 7, 6]),
+          text: new Uint8Array([0x61, 0x62, 0x63]) // 'abc'
+        })
+      );
+      const decoded = schema.decode(wire);
+
+      expect(Array.from(decoded.fixed)).toEqual([9, 8, 7, 6]);
+      expect(Array.from(decoded.text)).toEqual([0x61, 0x62, 0x63]);
+      expect(decoded.fixed.buffer).not.toBe(wire.buffer);
+      expect(decoded.text.buffer).not.toBe(wire.buffer);
+
+      wire.fill(0xff);
+      expect(Array.from(decoded.fixed)).toEqual([9, 8, 7, 6]);
+      expect(Array.from(decoded.text)).toEqual([0x61, 0x62, 0x63]);
+    });
+
+    it('a Buffer at a non-zero byteOffset decodes the correct window', () => {
+      const schema = varOpaque(1024);
+      const payload = [0, 0, 0, 4, 0xde, 0xad, 0xbe, 0xef];
+      // Place the wire bytes at offset 4 inside a larger buffer, then take a
+      // subarray view — a Buffer with byteOffset !== 0 over the same memory.
+      const big = Buffer.alloc(16, 0x55);
+      big.set(payload, 4);
+      const wire = big.subarray(4, 4 + payload.length);
+      expect(wire.byteOffset).not.toBe(0);
+
+      const decoded = schema.decode(wire);
+      expect(Array.from(decoded)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+      expect(decoded.buffer).not.toBe(big.buffer);
+    });
+
+    it('SharedArrayBuffer-backed input decodes to a normal exact-size ArrayBuffer', () => {
+      const schema = varOpaque(1024);
+      const sab = new SharedArrayBuffer(8);
+      const wire = new Uint8Array(sab);
+      wire.set([0, 0, 0, 4, 0x11, 0x22, 0x33, 0x44]);
+
+      const decoded = schema.decode(wire);
+      expect(Array.from(decoded)).toEqual([0x11, 0x22, 0x33, 0x44]);
+      expect(decoded.buffer).toBeInstanceOf(ArrayBuffer);
+      expect(decoded.buffer.byteLength).toBe(decoded.byteLength);
+    });
+
+    it('detached and zero-length inputs keep their current behavior', () => {
+      const schema = varOpaque(1024);
+
+      // Detach an ArrayBuffer while holding a view over it; the view then
+      // reports byteLength 0 and Reader's zero-length guard must handle it.
+      // (structuredClone with transfer detaches; ArrayBuffer.prototype.transfer
+      // is untyped under this project's ES2022 lib.)
+      const ab = new ArrayBuffer(8);
+      const view = new Uint8Array(ab);
+      structuredClone(ab, { transfer: [ab] });
+      expect(view.byteLength).toBe(0);
+
+      expect(schema.validateXdr(view)).toBe(false); // false, not a TypeError
+      expect(() => schema.decode(view)).toThrow(XdrError);
+
+      // A detached *Buffer* is the case that actually exercises the guard: a
+      // plain Uint8Array takes the fast path, but a subclass reaches the
+      // re-wrap, where constructing over a detached buffer would throw
+      // TypeError without the guard.
+      const ab2 = new ArrayBuffer(8);
+      const detachedBuf = Buffer.from(ab2);
+      structuredClone(ab2, { transfer: [ab2] });
+      expect(detachedBuf.byteLength).toBe(0);
+      expect(schema.validateXdr(detachedBuf)).toBe(false);
+      expect(() => schema.decode(detachedBuf)).toThrow(XdrError);
+
+      // Plain zero-length input: an empty schema decodes, a non-empty one
+      // throws XdrError — same as today.
+      const empty = new Uint8Array(0);
+      expect(voidType().decode(empty)).toBeUndefined();
+      expect(() => schema.decode(empty)).toThrow(XdrError);
+    });
+
+    it('a subclass that shadows `constructor` is still re-wrapped', () => {
+      // Distinguishes the prototype-identity check from a naive
+      // `bytes.constructor === Uint8Array` check, which this subclass passes
+      // while keeping an aliasing `slice`. defineProperty (instead of class
+      // method syntax) sidesteps TS override typing; the runtime shape is the
+      // same.
+      class Evil extends Uint8Array {}
+      Object.defineProperty(Evil.prototype, 'slice', {
+        value: Uint8Array.prototype.subarray
+      });
+      Object.defineProperty(Evil.prototype, 'constructor', {
+        value: Uint8Array
+      });
+
+      const schema = varOpaque(1024);
+      const backing = new Uint8Array([0, 0, 0, 4, 0xaa, 0xbb, 0xcc, 0xdd]);
+      const wire = new Evil(backing.buffer, 0, backing.byteLength);
+      const decoded = schema.decode(wire);
+
+      expect(Array.from(decoded)).toEqual([0xaa, 0xbb, 0xcc, 0xdd]);
+      expect(decoded.buffer).not.toBe(wire.buffer);
+      wire.fill(0, 4, 8);
+      expect(Array.from(decoded)).toEqual([0xaa, 0xbb, 0xcc, 0xdd]);
+    });
   });
 });


### PR DESCRIPTION
## What

`Reader` now normalizes its constructor input: a plain `Uint8Array` passes through untouched (prototype-identity fast path), any subclass is re-wrapped as a plain `Uint8Array` over the same memory, and zero-length/detached inputs keep their previous behavior. Adds tests pinning the copy invariant for `Buffer`, pool-backed, offset-view, `SharedArrayBuffer`-backed, detached, and constructor-shadowing inputs, plus a changelog entry.

## Why

`decode` promises to return copies, but `Reader.readBytes` used `this.bytes.slice(...)` on the input as given. `Buffer.prototype.slice` returns a view rather than a copy, so `opaque`/`varOpaque`/`string` values decoded from a Node `Buffer` — the pattern MIGRATION.md documents — aliased the caller's input: mutating either side silently changed the other, and pool-backed Buffers exposed Node's shared 8 KiB allocation pool through `decoded.buffer`. Normalizing once in the constructor fixes every byte-producing path at its single source. Benchmarks show no regression on real decode shapes; a tight loop of tiny decodes pays ~20 ns per call for the prototype check.