### PR TITLE
fix: reject detached and out-of-bounds Uint8Array values with XdrError

### DIFF
--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -65,7 +65,7 @@ export function assertUint8Array(
   }
   // Check if the Uint8Array is detached or out of bounds by attempting to access an element.
   try {
-    value.at(0);
+    Uint8Array.prototype.at.call(value, 0);
   } catch {
     throw new XdrError(`${path}: Uint8Array is detached or out of bounds`);
   }

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -63,6 +63,12 @@ export function assertUint8Array(
   if (!(value instanceof Uint8Array)) {
     throw new XdrError(`${path}: expected Uint8Array`);
   }
+  // Check if the Uint8Array is detached or out of bounds by attempting to access an element.
+  try {
+    value.at(0);
+  } catch {
+    throw new XdrError(`${path}: Uint8Array is detached or out of bounds`);
+  }
 }
 
 export function assertArray(

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -2,7 +2,7 @@ import { XdrError } from '../core/error.js';
 import type { Reader } from '../core/reader.js';
 import type { Writer } from '../core/writer.js';
 import { BaseType, type XdrType } from '../core/xdr-type.js';
-import { assertLength } from '../core/helpers.js';
+import { assertLength, assertUint8Array } from '../core/helpers.js';
 
 /**
  * Reads and writes XDR `string<N>` values as bytes.
@@ -30,9 +30,7 @@ class StringType extends BaseType<Uint8Array> {
   }
 
   _write(value: Uint8Array, writer: Writer, path: string): void {
-    if (!(value instanceof Uint8Array)) {
-      throw new XdrError(`${path}: expected Uint8Array`);
-    }
+    assertUint8Array(value, path);
     if (value.length > this.maxLength) {
       throw new XdrError(
         `${path}: string byte length ${value.length} exceeds maximum ${this.maxLength}`

--- a/test/unit/detached-buffer.test.ts
+++ b/test/unit/detached-buffer.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { varOpaque, string, opaque, XdrError } from '../../src/index.js';
+
+/**
+ * A Uint8Array whose buffer was detached, or whose span fell out of bounds
+ * under a shrunk resizable buffer, keeps its prototype and reports
+ * `length === 0`. Such a value must be rejected with an `XdrError` rather than
+ * reaching the writer, where reading it raises a native `TypeError`.
+ */
+
+function detachedView(byteLength: number): Uint8Array {
+  const buffer = new ArrayBuffer(byteLength);
+  const view = new Uint8Array(buffer);
+  structuredClone(view, { transfer: [buffer] });
+  return view;
+}
+
+function outOfBoundsView(): Uint8Array {
+  // Resizable ArrayBuffers are es2024; the tsconfig lib is ES2022, so reach
+  // the constructor options and `resize` through untyped handles.
+  const buffer = new (ArrayBuffer as unknown as {
+    new (length: number, options: { maxByteLength: number }): ArrayBuffer;
+  })(8, { maxByteLength: 8 });
+  const view = new Uint8Array(buffer, 4, 4);
+  (buffer as unknown as { resize(length: number): void }).resize(0);
+  return view;
+}
+
+describe('detached and out-of-bounds Uint8Array values', () => {
+  const cases = [
+    ['detached', detachedView(8)],
+    ['out of bounds', outOfBoundsView()]
+  ] as const;
+
+  for (const [label, view] of cases) {
+    describe(label, () => {
+      it('reports length 0 while keeping its prototype', () => {
+        expect(view).toBeInstanceOf(Uint8Array);
+        expect(view.length).toBe(0);
+      });
+
+      it.each([
+        ['varOpaque', varOpaque(64)],
+        ['string', string(64)],
+        ['opaque(0)', opaque(0)]
+      ])('%s.validate returns false', (_name, schema) => {
+        expect(schema.validate(view)).toBe(false);
+      });
+
+      it.each([
+        ['varOpaque', varOpaque(64)],
+        ['string', string(64)],
+        ['opaque(0)', opaque(0)]
+      ])('%s.encode throws an XdrError', (_name, schema) => {
+        expect(() => schema.encode(view)).toThrow(XdrError);
+        expect(() => schema.encode(view)).toThrow(/detached or out of bounds/);
+      });
+    });
+  }
+
+  it('still accepts a legitimately empty Uint8Array', () => {
+    expect(varOpaque(64).validate(new Uint8Array(0))).toBe(true);
+    expect(string(64).validate(new Uint8Array(0))).toBe(true);
+    expect(opaque(0).validate(new Uint8Array(0))).toBe(true);
+    expect(varOpaque(64).encode(new Uint8Array(0))).toEqual(
+      new Uint8Array([0, 0, 0, 0])
+    );
+  });
+
+  it('still accepts an empty subarray of a live buffer', () => {
+    const empty = new Uint8Array(8).subarray(4, 4);
+    expect(varOpaque(64).validate(empty)).toBe(true);
+    expect(string(64).validate(empty)).toBe(true);
+  });
+
+  it('still rejects a non-Uint8Array with the original message', () => {
+    expect(() => varOpaque(64).encode([] as unknown as Uint8Array)).toThrow(
+      /expected Uint8Array/
+    );
+  });
+});


### PR DESCRIPTION
## What

`assertUint8Array` now rejects a `Uint8Array` whose backing buffer has been detached, or whose span has fallen out of bounds under a shrunk resizable buffer, throwing `XdrError` rather than letting the value reach the writer. The check calls `value.at(0)`, which runs the spec's `ValidateTypedArray` step and throws for exactly those two states: an empty array, an out-of-range index, a `SharedArrayBuffer` view, and a grown resizable buffer all return normally. `StringType._write` now calls the shared helper instead of its own inlined `instanceof` check, so `string` is covered alongside `varOpaque` and `opaque`. New tests cover both bad shapes across all three types and pin the cases that must keep working: an empty `Uint8Array`, an empty subarray of a live buffer, and the existing `expected Uint8Array` message for non-typed-array input.

## Why

A view over a detached buffer keeps its `Uint8Array` prototype and reports `length === 0`, so it passed both encode-side gates and reached `Writer.writeBytes`, where `%TypedArray%.prototype.set` throws a native `TypeError`. `BaseType.validate` converts only `XdrError` into `false` and rethrows anything else, and `BaseType.encode` does not catch at all, so that `TypeError` escaped to the caller. That broke the documented contract that `validate` is a non-throwing predicate and `encode` fails with `XdrError`, and it is reachable through ordinary platform APIs: a worker `postMessage`, `structuredClone` with a transfer list, `ArrayBuffer.prototype.transfer`, or `resize` on a resizable buffer. No type violation is involved, since a detached view still satisfies the declared `Uint8Array` type and TypeScript has no way to express "not detached", so a type-correct caller holding a stale view after a zero-copy handoff could hit it.
