### PR TITLE
fix(option): reject a present option that decodes to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - `option` rejects a present option whose element decodes to `null`. Absence is
   already `null`, so such a value would have two wire forms and would not
   re-encode to the bytes it came from; `decode` throws an `XdrError` instead of
-  collapsing them. The wire form is legal XDR — to exchange it with a peer, put
-  a single-field struct between the two optionals.
+  collapsing them. This covers a nested optional and any custom element type
+  that uses `null` as a real value. The wire form is legal XDR — to exchange it
+  with a peer, wrap the element in a single-field struct, which gives each form
+  its own JavaScript value.
 
 ### Fixed
 
@@ -91,8 +93,10 @@ step-by-step upgrade guide.
 - **An absent `option` is now `null`, not `undefined`.** v4's `Option.read`
   returned `undefined` when the presence flag was false, and its `write`
   accepted either `null` or `undefined` as absent. v5 reads and writes `null`
-  only; `undefined` is treated as a present value and fails inside the element
-  type. Audit call sites that omit an optional field by leaving it `undefined`.
+  only; `undefined` no longer means absence and is handed to the element type as
+  a present value, which most element types reject (though `option(void())`, for
+  one, encodes it as a present void). Audit call sites that omit an optional
+  field by leaving it `undefined`.
 - **New package layout.** `main`/`module`/`browser` fields are replaced by an
   `exports` map exposing dual ESM (`dist/js-xdr.mjs`) and CommonJS
   (`dist/js-xdr.cjs`) builds plus generated type declarations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ step-by-step upgrade guide.
   `fixedArray(element, length)`; its variable-length `VarArray` →
   `array(element, maxLength)`. Note the flip: `array` is the **variable-length**
   type in v5 (it was fixed-length in v4), so audit existing call sites.
+- **An absent `option` is now `null`, not `undefined`.** v4's `Option.read`
+  returned `undefined` when the presence flag was false, and its `write`
+  accepted either `null` or `undefined` as absent. v5 reads and writes `null`
+  only; `undefined` is treated as a present value and fails inside the element
+  type. Audit call sites that omit an optional field by leaving it `undefined`.
 - **New package layout.** `main`/`module`/`browser` fields are replaced by an
   `exports` map exposing dual ESM (`dist/js-xdr.mjs`) and CommonJS
   (`dist/js-xdr.cjs`) builds plus generated type declarations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
   wrong bytes.
 - `Reader` and `Writer` reject a non-integer or negative `maxDepth` with an
   `XdrError` instead of silently disabling the recursion guard.
+- `option` rejects a present option whose element decodes to `null`. Absence is
+  already `null`, so such a value would have two wire forms and would not
+  re-encode to the bytes it came from; `decode` throws an `XdrError` instead of
+  collapsing them. The wire form is legal XDR — to exchange it with a peer, put
+  a single-field struct between the two optionals.
 
 ### Fixed
 

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -20,7 +20,22 @@ class OptionType<T> extends BaseType<T | null> {
     reader.enter(path);
     try {
       const present = BOOL_TYPE._read(reader, `${path}.present`);
-      return present ? this.element._read(reader, `${path}.value`) : null;
+      if (!present) {
+        return null;
+      }
+      const value = this.element._read(reader, `${path}.value`);
+      // A present option whose element decoded to `null` is indistinguishable
+      // from an absent one, so the same value would have two wire forms and
+      // re-encoding would not reproduce these bytes. Reject the non-canonical
+      // form rather than silently collapsing it.
+      if (value === null) {
+        throw new XdrError(
+          `${path}: present option decoded to null, which is how an absent ` +
+            `option is represented; wrap the element in a single-field ` +
+            `struct to distinguish the two`
+        );
+      }
+      return value;
     } finally {
       reader.exit();
     }
@@ -45,15 +60,36 @@ class OptionType<T> extends BaseType<T | null> {
  * Values are represented as either the element value or `null`. The wire format
  * writes a boolean presence flag first; when the flag is `true`, the element
  * value follows.
+ *
+ * Because `null` marks absence, the element type must never decode to `null`
+ * itself — the two would be the same JavaScript value. Decoding a present
+ * option whose element produced `null` throws rather than collapsing the two
+ * forms. This rules out a nested optional, and also a custom type that uses
+ * `null` as an inhabited value (a JSON-style schema with a null arm, say).
+ *
+ * Both are still expressible: put a single-field struct between the two
+ * levels. `option(struct('Wrapped', { value: option(int32()) }))` has the same
+ * wire format as a nested optional and maps each of the three forms to a
+ * distinct value — `null`, `{ value: null }`, `{ value: 7 }`.
  */
 export function option<T extends XdrType<unknown>>(
   element: T
 ): OptionSchema<Infer<T> | null> {
-  // An absent outer option and a present-but-null inner option would both map
-  // to JS `null`, giving one value two wire encodings (and a lossy re-encode).
-  // XDR IDL cannot express a directly nested optional either.
+  // An absent outer option and a present-but-absent inner one would both map to
+  // JS `null`, giving one value two wire encodings (and a lossy re-encode). The
+  // wire form is legal XDR — RFC 4506 reaches it through a typedef — so this is
+  // a limit of the representation here, not of the format.
+  //
+  // This is an early, clearer error for the obvious case; it is not the
+  // enforcement point. The element can reach `null` through a `lazy` wrapper or
+  // a custom type, neither of which this check can see, so `_read` rejects a
+  // present option that decoded to `null` whatever produced it.
   if (element.kind === 'option') {
-    throw new XdrError('option: cannot nest option directly inside option');
+    throw new XdrError(
+      'option: cannot nest option directly inside option, since an absent ' +
+        'outer option and a present-but-absent inner one are both `null`; ' +
+        'wrap the inner option in a single-field struct instead'
+    );
   }
   return new OptionType(element) as unknown as OptionSchema<Infer<T> | null>;
 }

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -26,8 +26,9 @@ class OptionType<T> extends BaseType<T | null> {
       const value = this.element._read(reader, `${path}.value`);
       // A present option whose element decoded to `null` is indistinguishable
       // from an absent one, so the same value would have two wire forms and
-      // re-encoding would not reproduce these bytes. Reject the non-canonical
-      // form rather than silently collapsing it.
+      // re-encoding would not reproduce these bytes. Both forms are valid XDR;
+      // it is the representation here that cannot hold them apart, so reject
+      // these bytes rather than silently collapsing them into the shorter form.
       if (value === null) {
         throw new XdrError(
           `${path}: present option decoded to null, which is how an absent ` +

--- a/test/unit/option.test.ts
+++ b/test/unit/option.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { option, int32 } from '../../src/index.js';
+import { option, int32, lazy, struct, BaseType } from '../../src/index.js';
+import type { Reader, Writer, XdrType } from '../../src/index.js';
 import { bytes, toArray, roundTrip } from './_helpers.js';
 
 const schema = option(int32());
@@ -8,6 +9,10 @@ describe('option', () => {
   describe('encode', () => {
     it('writes a present flag plus the value when set', () => {
       expect(toArray(schema.encode(5))).toEqual([0, 0, 0, 1, 0, 0, 0, 5]);
+    });
+
+    it('writes a present flag plus the value when set', () => {
+      expect(toArray(schema.encode(0))).toEqual([0, 0, 0, 1, 0, 0, 0, 0]);
     });
 
     it('writes only the absent flag for null', () => {
@@ -19,7 +24,9 @@ describe('option', () => {
     it('reads the present flag then the value', () => {
       expect(schema.decode(bytes([0, 0, 0, 1, 0, 0, 0, 5]))).toBe(5);
     });
-
+    it('reads the present flag then the value', () => {
+      expect(schema.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toBe(0);
+    });
     it('reads null when the flag is absent', () => {
       expect(schema.decode(bytes([0, 0, 0, 0]))).toBeNull();
     });
@@ -34,5 +41,83 @@ describe('option', () => {
     // Absent-outer and present-but-null-inner would both decode to `null`,
     // giving one JS value two wire encodings.
     expect(() => option(option(int32()))).toThrow(/cannot nest option/i);
+  });
+
+  describe('present-but-null decode', () => {
+    // The construction check above only sees the element's own `kind`, so it
+    // cannot catch an element that reaches `null` indirectly. `_read` rejects
+    // the collapsed form instead, whatever produced it.
+
+    it('rejects a nested option reached through lazy', () => {
+      const nested = option(lazy(() => option(int32())));
+
+      expect(nested.decode(bytes([0, 0, 0, 0]))).toBeNull();
+      // Match the message, not just `XdrError`: trailing-byte and depth
+      // failures raise the same class.
+      expect(() => nested.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toThrow(
+        /present option decoded to null/
+      );
+      // A present, non-null value still decodes through the wrapper.
+      expect(nested.decode(bytes([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 7]))).toBe(
+        7
+      );
+    });
+
+    it('rejects a custom element type that decodes to null', () => {
+      class NullableInt extends BaseType<number | null> {
+        readonly kind = 'custom';
+
+        _read(reader: Reader, path: string): number | null {
+          return reader.readInt32(path) === 0 ? null : reader.readInt32(path);
+        }
+
+        _write(value: number | null, writer: Writer): void {
+          writer.writeInt32(value === null ? 0 : 1);
+          if (value !== null) {
+            writer.writeInt32(value);
+          }
+        }
+      }
+
+      const schema = option(new NullableInt());
+
+      expect(schema.decode(bytes([0, 0, 0, 0]))).toBeNull();
+      expect(() => schema.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toThrow(
+        /present option decoded to null/
+      );
+    });
+
+    it('accepts a null nested one level deeper, which is unambiguous', () => {
+      // `null` and `{ x: null }` are distinct JS values with distinct wires,
+      // so the check must not fire here. This is also the documented way to
+      // exchange a nested optional with a peer: the struct costs no bytes, so
+      // the three wire forms below are exactly those of `option(option(x))`,
+      // and each maps to its own JS value and round-trips.
+      const schema = option(struct('S', { x: option(int32()) }));
+
+      expect(schema.decode(bytes([0, 0, 0, 0]))).toBeNull();
+      expect(schema.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toEqual({
+        x: null
+      });
+      expect(
+        schema.decode(bytes([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 7]))
+      ).toEqual({ x: 7 });
+
+      expect(roundTrip(schema, null)).toBeNull();
+      expect(roundTrip(schema, { x: null })).toEqual({ x: null });
+      expect(roundTrip(schema, { x: 7 })).toEqual({ x: 7 });
+    });
+
+    it('accepts the recursive lazy idiom', () => {
+      const node: XdrType<unknown> = struct('Node', {
+        value: int32(),
+        next: option(lazy((): XdrType<unknown> => node))
+      });
+
+      expect(node.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toEqual({
+        value: 1,
+        next: null
+      });
+    });
   });
 });

--- a/test/unit/option.test.ts
+++ b/test/unit/option.test.ts
@@ -11,7 +11,7 @@ describe('option', () => {
       expect(toArray(schema.encode(5))).toEqual([0, 0, 0, 1, 0, 0, 0, 5]);
     });
 
-    it('writes a present flag plus the value when set', () => {
+    it('writes a present flag plus a zero value, not the absent flag', () => {
       expect(toArray(schema.encode(0))).toEqual([0, 0, 0, 1, 0, 0, 0, 0]);
     });
 
@@ -24,7 +24,7 @@ describe('option', () => {
     it('reads the present flag then the value', () => {
       expect(schema.decode(bytes([0, 0, 0, 1, 0, 0, 0, 5]))).toBe(5);
     });
-    it('reads the present flag then the value', () => {
+    it('reads a present zero value, not null', () => {
       expect(schema.decode(bytes([0, 0, 0, 1, 0, 0, 0, 0]))).toBe(0);
     });
     it('reads null when the flag is absent', () => {


### PR DESCRIPTION
## What

`option` decoding now throws an `XdrError` when a present option's element decodes to `null`, instead of returning `null` and collapsing it into the absent case. The construction-time `option(option(x))` check stays as an earlier, clearer error, but it only inspects the element's own `kind`, so it misses an element that reaches `null` through `lazy` or a custom type; the decode check covers those.

Also updates the `option` JSDoc and both error messages to explain the constraint and point at the fix, and backfills a changelog entry for a v5 break that was never recorded: an absent option is `null` now, where v4 read `undefined` and accepted either on write.

## Why

Absence is represented as `null`, so an element that also decodes to `null` gives one JavaScript value two wire forms. Re-encoding picks the shorter one, so the bytes that come out are not the bytes that went in, and nothing in the decoded value records which form it came from. v4 collapsed this silently; failing loudly is better than returning a value that will not round-trip.

The longer wire form is legal XDR (RFC 4506 reaches a nested optional through a typedef), so this is a limit of the JavaScript representation rather than a claim that the bytes are malformed. Both the nested optional and a custom type that uses `null` as a real value are still expressible by putting a single-field struct between the two levels: `option(struct('Wrapped', { value: option(int32()) }))` has the same wire format and maps each form to a distinct value. The error messages and docs say so, and a test covers that the three forms round-trip.
