### PR TITLE
test: add vitest benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ lib/
 node_modules/
 tmp/
 generated/
+bench-baseline.json
 .DS_Store
 .vscode

--- a/bench/_bench.ts
+++ b/bench/_bench.ts
@@ -1,0 +1,19 @@
+import { bench, type BenchOptions } from 'vitest';
+
+// Keep each benchmark short so the whole suite stays fast; raise `time`
+// locally when chasing small regressions.
+const BENCH_OPTS: BenchOptions = { time: 250 };
+
+// Register every benchmark through this wrapper so no case silently falls
+// back to vitest's default 500 ms run time and skews the table.
+export function b(name: string, fn: () => void): void {
+  bench(name, fn, BENCH_OPTS);
+}
+
+export function fill(length: number, seed = 7): Uint8Array {
+  const out = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) {
+    out[i] = (i * seed + 3) & 0xff;
+  }
+  return out;
+}

--- a/bench/_fixtures.ts
+++ b/bench/_fixtures.ts
@@ -1,6 +1,6 @@
-import type { BenchOptions } from 'vitest';
 import {
   array,
+  bool,
   enumType,
   fixedArray,
   int32,
@@ -18,28 +18,19 @@ import {
   void as voidType,
   type XdrType
 } from '../src/index.js';
-
-// Keep each benchmark short so the whole suite stays fast; raise `time`
-// locally when chasing small regressions.
-export const BENCH_OPTS: BenchOptions = { time: 250 };
-
-export function fill(length: number, seed = 7): Uint8Array {
-  const out = new Uint8Array(length);
-  for (let i = 0; i < length; i += 1) {
-    out[i] = (i * seed + 3) & 0xff;
-  }
-  return out;
-}
+import { fill } from './_bench.js';
 
 // -- Flat struct ------------------------------------------------------------
 
+// Mirrors the Range schema in test/unit/struct.test.ts, bool() included, so
+// the struct benches also cover the bool codec path.
 export const Range = struct('Range', {
   begin: int32(),
   end: int32(),
-  inclusive: int32()
+  inclusive: bool()
 });
 
-export const RANGE_VALUE = { begin: 5, end: 255, inclusive: 1 };
+export const RANGE_VALUE = { begin: 5, end: 255, inclusive: true };
 export const RANGE_BYTES = Range.encode(RANGE_VALUE);
 
 export const Line = struct('Line', { a: Range, b: Range });
@@ -50,7 +41,7 @@ export const LINE_BYTES = Line.encode(LINE_VALUE);
 
 const PublicKeyType = enumType('PublicKeyType', { ed25519: 0 });
 
-export const PublicKey = union('PublicKey', {
+const PublicKey = union('PublicKey', {
   switchOn: PublicKeyType,
   cases: [
     caseOf('ed25519', PublicKeyType.ed25519, field('ed25519', opaque(32)))
@@ -64,7 +55,7 @@ const CreditAsset = struct('CreditAsset', {
   issuer: PublicKey
 });
 
-export const Asset = union('Asset', {
+const Asset = union('Asset', {
   switchOn: AssetType,
   cases: [
     caseOf('native', AssetType.native, voidType()),
@@ -99,8 +90,6 @@ export const Transaction = struct('Transaction', {
   signatures: array(fixedArray(opaque(64), 1), 20)
 });
 
-export type PaymentValue = ReturnType<typeof makePayment>;
-
 export function makePayment(i: number) {
   return {
     destination: { type: 0 as const, ed25519: fill(32, i + 1) },
@@ -118,7 +107,7 @@ export function makePayment(i: number) {
   };
 }
 
-export function makeTransaction(operationCount: number) {
+function makeTransaction(operationCount: number) {
   const operations = [];
   for (let i = 0; i < operationCount; i += 1) {
     operations.push(makePayment(i));
@@ -148,7 +137,7 @@ export const LinkedList: XdrType<ListNode> = struct('ListNode', {
   next: option(lazy((): XdrType<ListNode> => LinkedList))
 });
 
-export function makeList(length: number): ListNode {
+function makeList(length: number): ListNode {
   let node: ListNode = { value: 0, next: null };
   for (let i = 1; i < length; i += 1) {
     node = { value: i, next: node };
@@ -156,5 +145,8 @@ export function makeList(length: number): ListNode {
   return node;
 }
 
+// Each node costs 3 recursion-depth units (struct + option + lazy), so with
+// the default maxDepth of 1500 the ceiling is 500 nodes. 300 leaves headroom;
+// going past 500 throws "max recursion depth exceeded" at module load.
 export const LIST_VALUE = makeList(300);
 export const LIST_BYTES = LinkedList.encode(LIST_VALUE);

--- a/bench/_fixtures.ts
+++ b/bench/_fixtures.ts
@@ -1,0 +1,160 @@
+import type { BenchOptions } from 'vitest';
+import {
+  array,
+  enumType,
+  fixedArray,
+  int32,
+  int64,
+  lazy,
+  opaque,
+  option,
+  string,
+  struct,
+  uint32,
+  uint64,
+  union,
+  case as caseOf,
+  field,
+  void as voidType,
+  type XdrType
+} from '../src/index.js';
+
+// Keep each benchmark short so the whole suite stays fast; raise `time`
+// locally when chasing small regressions.
+export const BENCH_OPTS: BenchOptions = { time: 250 };
+
+export function fill(length: number, seed = 7): Uint8Array {
+  const out = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) {
+    out[i] = (i * seed + 3) & 0xff;
+  }
+  return out;
+}
+
+// -- Flat struct ------------------------------------------------------------
+
+export const Range = struct('Range', {
+  begin: int32(),
+  end: int32(),
+  inclusive: int32()
+});
+
+export const RANGE_VALUE = { begin: 5, end: 255, inclusive: 1 };
+export const RANGE_BYTES = Range.encode(RANGE_VALUE);
+
+export const Line = struct('Line', { a: Range, b: Range });
+export const LINE_VALUE = { a: RANGE_VALUE, b: RANGE_VALUE };
+export const LINE_BYTES = Line.encode(LINE_VALUE);
+
+// -- Stellar-flavored transaction schema -------------------------------------
+
+const PublicKeyType = enumType('PublicKeyType', { ed25519: 0 });
+
+export const PublicKey = union('PublicKey', {
+  switchOn: PublicKeyType,
+  cases: [
+    caseOf('ed25519', PublicKeyType.ed25519, field('ed25519', opaque(32)))
+  ]
+});
+
+const AssetType = enumType('AssetType', { native: 0, credit: 1 });
+
+const CreditAsset = struct('CreditAsset', {
+  code: opaque(4),
+  issuer: PublicKey
+});
+
+export const Asset = union('Asset', {
+  switchOn: AssetType,
+  cases: [
+    caseOf('native', AssetType.native, voidType()),
+    caseOf('credit', AssetType.credit, field('credit', CreditAsset))
+  ]
+});
+
+const MemoType = enumType('MemoType', { none: 0, text: 1, id: 2, hash: 3 });
+
+export const Memo = union('Memo', {
+  switchOn: MemoType,
+  cases: [
+    caseOf('none', MemoType.none, voidType()),
+    caseOf('text', MemoType.text, field('text', string(28))),
+    caseOf('id', MemoType.id, field('id', uint64())),
+    caseOf('hash', MemoType.hash, field('hash', opaque(32)))
+  ]
+});
+
+export const Payment = struct('Payment', {
+  destination: PublicKey,
+  asset: Asset,
+  amount: int64()
+});
+
+export const Transaction = struct('Transaction', {
+  source: PublicKey,
+  fee: uint32(),
+  seqNum: int64(),
+  memo: Memo,
+  operations: array(Payment, 100),
+  signatures: array(fixedArray(opaque(64), 1), 20)
+});
+
+export type PaymentValue = ReturnType<typeof makePayment>;
+
+export function makePayment(i: number) {
+  return {
+    destination: { type: 0 as const, ed25519: fill(32, i + 1) },
+    asset:
+      i % 2 === 0
+        ? { type: 0 as const }
+        : {
+            type: 1 as const,
+            credit: {
+              code: fill(4, i + 2),
+              issuer: { type: 0 as const, ed25519: fill(32, i + 3) }
+            }
+          },
+    amount: BigInt(i) * 10_000_000n
+  };
+}
+
+export function makeTransaction(operationCount: number) {
+  const operations = [];
+  for (let i = 0; i < operationCount; i += 1) {
+    operations.push(makePayment(i));
+  }
+  return {
+    source: { type: 0 as const, ed25519: fill(32) },
+    fee: 100 * operationCount,
+    seqNum: 123_456_789_012n,
+    memo: { type: 2 as const, id: 987_654_321n },
+    operations,
+    signatures: [[fill(64, 11)], [fill(64, 13)]]
+  };
+}
+
+export const TX_VALUE = makeTransaction(20);
+export const TX_BYTES = Transaction.encode(TX_VALUE);
+
+// -- Recursive schema (lazy + option) ----------------------------------------
+
+interface ListNode {
+  value: number;
+  next: ListNode | null;
+}
+
+export const LinkedList: XdrType<ListNode> = struct('ListNode', {
+  value: int32(),
+  next: option(lazy((): XdrType<ListNode> => LinkedList))
+});
+
+export function makeList(length: number): ListNode {
+  let node: ListNode = { value: 0, next: null };
+  for (let i = 1; i < length; i += 1) {
+    node = { value: i, next: node };
+  }
+  return node;
+}
+
+export const LIST_VALUE = makeList(300);
+export const LIST_BYTES = LinkedList.encode(LIST_VALUE);

--- a/bench/bytes.bench.ts
+++ b/bench/bytes.bench.ts
@@ -1,59 +1,52 @@
-import { bench, describe } from 'vitest';
+import { describe } from 'vitest';
 import { opaque, string, varOpaque } from '../src/index.js';
-import { BENCH_OPTS, fill } from './_fixtures.js';
+import { b, fill } from './_bench.js';
 
+// 60 000 B stays below Writer's 65 536 B power-of-two growth boundary even
+// with a 4-byte length prefix, so opaque and varOpaque encodes pay the same
+// number of buffer doublings and their numbers stay comparable.
 const SMALL = fill(32);
-const LARGE = fill(65_536);
+const LARGE = fill(60_000);
+// Unaligned lengths force the padding read/write branch, which 4-byte-aligned
+// payloads never touch.
+const SMALL_UNALIGNED = fill(33);
+const LARGE_UNALIGNED = fill(59_997);
 
 const Opaque32 = opaque(32);
-const Opaque64k = opaque(65_536);
-const VarOpaque64k = varOpaque(65_536);
-const String64k = string(65_536);
+const Opaque60k = opaque(60_000);
+const VarOpaque60k = varOpaque(60_000);
+const String60k = string(60_000);
 
 const OPAQUE32_BYTES = Opaque32.encode(SMALL);
-const OPAQUE64K_BYTES = Opaque64k.encode(LARGE);
-const VAR_SMALL_BYTES = VarOpaque64k.encode(SMALL);
-const VAR_LARGE_BYTES = VarOpaque64k.encode(LARGE);
-const STRING_SMALL_BYTES = String64k.encode(SMALL);
-const STRING_LARGE_BYTES = String64k.encode(LARGE);
+const OPAQUE60K_BYTES = Opaque60k.encode(LARGE);
+const VAR_SMALL_BYTES = VarOpaque60k.encode(SMALL);
+const VAR_LARGE_BYTES = VarOpaque60k.encode(LARGE);
+const STRING_SMALL_BYTES = String60k.encode(SMALL_UNALIGNED);
+const STRING_LARGE_BYTES = String60k.encode(LARGE_UNALIGNED);
 
 describe('opaque', () => {
-  bench('encode 32 B', () => void Opaque32.encode(SMALL), BENCH_OPTS);
-  bench('decode 32 B', () => void Opaque32.decode(OPAQUE32_BYTES), BENCH_OPTS);
-  bench('encode 64 KiB', () => void Opaque64k.encode(LARGE), BENCH_OPTS);
-  bench(
-    'decode 64 KiB',
-    () => void Opaque64k.decode(OPAQUE64K_BYTES),
-    BENCH_OPTS
-  );
+  b('encode 32 B', () => void Opaque32.encode(SMALL));
+  b('decode 32 B', () => void Opaque32.decode(OPAQUE32_BYTES));
+  b('encode 60 kB', () => void Opaque60k.encode(LARGE));
+  b('decode 60 kB', () => void Opaque60k.decode(OPAQUE60K_BYTES));
 });
 
 describe('varOpaque', () => {
-  bench('encode 32 B', () => void VarOpaque64k.encode(SMALL), BENCH_OPTS);
-  bench(
-    'decode 32 B',
-    () => void VarOpaque64k.decode(VAR_SMALL_BYTES),
-    BENCH_OPTS
-  );
-  bench('encode 64 KiB', () => void VarOpaque64k.encode(LARGE), BENCH_OPTS);
-  bench(
-    'decode 64 KiB',
-    () => void VarOpaque64k.decode(VAR_LARGE_BYTES),
-    BENCH_OPTS
-  );
+  b('encode 32 B', () => void VarOpaque60k.encode(SMALL));
+  b('decode 32 B', () => void VarOpaque60k.decode(VAR_SMALL_BYTES));
+  b('encode 60 kB', () => void VarOpaque60k.encode(LARGE));
+  b('decode 60 kB', () => void VarOpaque60k.decode(VAR_LARGE_BYTES));
 });
 
+// string shares varOpaque's aligned code path line for line, so these benches
+// use unaligned payloads to cover the padding branch instead of duplicating
+// the varOpaque numbers.
 describe('string', () => {
-  bench('encode 32 B', () => void String64k.encode(SMALL), BENCH_OPTS);
-  bench(
-    'decode 32 B',
-    () => void String64k.decode(STRING_SMALL_BYTES),
-    BENCH_OPTS
-  );
-  bench('encode 64 KiB', () => void String64k.encode(LARGE), BENCH_OPTS);
-  bench(
-    'decode 64 KiB',
-    () => void String64k.decode(STRING_LARGE_BYTES),
-    BENCH_OPTS
+  b('encode 33 B (unaligned)', () => void String60k.encode(SMALL_UNALIGNED));
+  b('decode 33 B (unaligned)', () => void String60k.decode(STRING_SMALL_BYTES));
+  b('encode 60 kB (unaligned)', () => void String60k.encode(LARGE_UNALIGNED));
+  b(
+    'decode 60 kB (unaligned)',
+    () => void String60k.decode(STRING_LARGE_BYTES)
   );
 });

--- a/bench/bytes.bench.ts
+++ b/bench/bytes.bench.ts
@@ -1,0 +1,59 @@
+import { bench, describe } from 'vitest';
+import { opaque, string, varOpaque } from '../src/index.js';
+import { BENCH_OPTS, fill } from './_fixtures.js';
+
+const SMALL = fill(32);
+const LARGE = fill(65_536);
+
+const Opaque32 = opaque(32);
+const Opaque64k = opaque(65_536);
+const VarOpaque64k = varOpaque(65_536);
+const String64k = string(65_536);
+
+const OPAQUE32_BYTES = Opaque32.encode(SMALL);
+const OPAQUE64K_BYTES = Opaque64k.encode(LARGE);
+const VAR_SMALL_BYTES = VarOpaque64k.encode(SMALL);
+const VAR_LARGE_BYTES = VarOpaque64k.encode(LARGE);
+const STRING_SMALL_BYTES = String64k.encode(SMALL);
+const STRING_LARGE_BYTES = String64k.encode(LARGE);
+
+describe('opaque', () => {
+  bench('encode 32 B', () => void Opaque32.encode(SMALL), BENCH_OPTS);
+  bench('decode 32 B', () => void Opaque32.decode(OPAQUE32_BYTES), BENCH_OPTS);
+  bench('encode 64 KiB', () => void Opaque64k.encode(LARGE), BENCH_OPTS);
+  bench(
+    'decode 64 KiB',
+    () => void Opaque64k.decode(OPAQUE64K_BYTES),
+    BENCH_OPTS
+  );
+});
+
+describe('varOpaque', () => {
+  bench('encode 32 B', () => void VarOpaque64k.encode(SMALL), BENCH_OPTS);
+  bench(
+    'decode 32 B',
+    () => void VarOpaque64k.decode(VAR_SMALL_BYTES),
+    BENCH_OPTS
+  );
+  bench('encode 64 KiB', () => void VarOpaque64k.encode(LARGE), BENCH_OPTS);
+  bench(
+    'decode 64 KiB',
+    () => void VarOpaque64k.decode(VAR_LARGE_BYTES),
+    BENCH_OPTS
+  );
+});
+
+describe('string', () => {
+  bench('encode 32 B', () => void String64k.encode(SMALL), BENCH_OPTS);
+  bench(
+    'decode 32 B',
+    () => void String64k.decode(STRING_SMALL_BYTES),
+    BENCH_OPTS
+  );
+  bench('encode 64 KiB', () => void String64k.encode(LARGE), BENCH_OPTS);
+  bench(
+    'decode 64 KiB',
+    () => void String64k.decode(STRING_LARGE_BYTES),
+    BENCH_OPTS
+  );
+});

--- a/bench/composite.bench.ts
+++ b/bench/composite.bench.ts
@@ -1,0 +1,129 @@
+import { bench, describe } from 'vitest';
+import { array, enumType, fixedArray, int32, option } from '../src/index.js';
+import {
+  BENCH_OPTS,
+  Line,
+  LINE_BYTES,
+  LINE_VALUE,
+  Memo,
+  Range,
+  RANGE_BYTES,
+  RANGE_VALUE,
+  makePayment,
+  Payment
+} from './_fixtures.js';
+
+const Color = enumType('Color', { red: 0, green: 1, blue: 2 });
+const COLOR_BYTES = Color.encode(Color.green);
+
+const OptInt = option(int32());
+const OPT_PRESENT_BYTES = OptInt.encode(7);
+const OPT_ABSENT_BYTES = OptInt.encode(null);
+
+const MEMO_VOID_BYTES = Memo.encode({ type: 0 });
+const MEMO_ID_VALUE = { type: 2 as const, id: 987_654_321n };
+const MEMO_ID_BYTES = Memo.encode(MEMO_ID_VALUE);
+
+const IntArray = array(int32(), 10_000);
+const IntFixedArray = fixedArray(int32(), 1000);
+const INTS_10 = Array.from({ length: 10 }, (_, i) => i);
+const INTS_1000 = Array.from({ length: 1000 }, (_, i) => i);
+const INT_ARRAY_10_BYTES = IntArray.encode(INTS_10);
+const INT_ARRAY_1000_BYTES = IntArray.encode(INTS_1000);
+const INT_FIXED_1000_BYTES = IntFixedArray.encode(INTS_1000);
+
+const PaymentArray = array(Payment, 1000);
+const PAYMENTS_100 = Array.from({ length: 100 }, (_, i) => makePayment(i));
+const PAYMENT_ARRAY_BYTES = PaymentArray.encode(PAYMENTS_100);
+
+describe('enum', () => {
+  bench('encode', () => void Color.encode(Color.green), BENCH_OPTS);
+  bench('decode', () => void Color.decode(COLOR_BYTES), BENCH_OPTS);
+});
+
+describe('struct', () => {
+  bench(
+    'encode flat (3 fields)',
+    () => void Range.encode(RANGE_VALUE),
+    BENCH_OPTS
+  );
+  bench(
+    'decode flat (3 fields)',
+    () => void Range.decode(RANGE_BYTES),
+    BENCH_OPTS
+  );
+  bench('encode nested', () => void Line.encode(LINE_VALUE), BENCH_OPTS);
+  bench('decode nested', () => void Line.decode(LINE_BYTES), BENCH_OPTS);
+});
+
+describe('union', () => {
+  bench('encode void arm', () => void Memo.encode({ type: 0 }), BENCH_OPTS);
+  bench('decode void arm', () => void Memo.decode(MEMO_VOID_BYTES), BENCH_OPTS);
+  bench(
+    'encode payload arm',
+    () => void Memo.encode(MEMO_ID_VALUE),
+    BENCH_OPTS
+  );
+  bench(
+    'decode payload arm',
+    () => void Memo.decode(MEMO_ID_BYTES),
+    BENCH_OPTS
+  );
+});
+
+describe('option', () => {
+  bench('encode present', () => void OptInt.encode(7), BENCH_OPTS);
+  bench(
+    'decode present',
+    () => void OptInt.decode(OPT_PRESENT_BYTES),
+    BENCH_OPTS
+  );
+  bench('encode absent', () => void OptInt.encode(null), BENCH_OPTS);
+  bench(
+    'decode absent',
+    () => void OptInt.decode(OPT_ABSENT_BYTES),
+    BENCH_OPTS
+  );
+});
+
+describe('array of int32', () => {
+  bench('encode 10 elements', () => void IntArray.encode(INTS_10), BENCH_OPTS);
+  bench(
+    'decode 10 elements',
+    () => void IntArray.decode(INT_ARRAY_10_BYTES),
+    BENCH_OPTS
+  );
+  bench(
+    'encode 1000 elements',
+    () => void IntArray.encode(INTS_1000),
+    BENCH_OPTS
+  );
+  bench(
+    'decode 1000 elements',
+    () => void IntArray.decode(INT_ARRAY_1000_BYTES),
+    BENCH_OPTS
+  );
+  bench(
+    'encode 1000 elements (fixed)',
+    () => void IntFixedArray.encode(INTS_1000),
+    BENCH_OPTS
+  );
+  bench(
+    'decode 1000 elements (fixed)',
+    () => void IntFixedArray.decode(INT_FIXED_1000_BYTES),
+    BENCH_OPTS
+  );
+});
+
+describe('array of structs', () => {
+  bench(
+    'encode 100 payments',
+    () => void PaymentArray.encode(PAYMENTS_100),
+    BENCH_OPTS
+  );
+  bench(
+    'decode 100 payments',
+    () => void PaymentArray.decode(PAYMENT_ARRAY_BYTES),
+    BENCH_OPTS
+  );
+});

--- a/bench/composite.bench.ts
+++ b/bench/composite.bench.ts
@@ -1,7 +1,7 @@
-import { bench, describe } from 'vitest';
+import { describe } from 'vitest';
 import { array, enumType, fixedArray, int32, option } from '../src/index.js';
+import { b } from './_bench.js';
 import {
-  BENCH_OPTS,
   Line,
   LINE_BYTES,
   LINE_VALUE,
@@ -20,7 +20,8 @@ const OptInt = option(int32());
 const OPT_PRESENT_BYTES = OptInt.encode(7);
 const OPT_ABSENT_BYTES = OptInt.encode(null);
 
-const MEMO_VOID_BYTES = Memo.encode({ type: 0 });
+const MEMO_VOID_VALUE = { type: 0 as const };
+const MEMO_VOID_BYTES = Memo.encode(MEMO_VOID_VALUE);
 const MEMO_ID_VALUE = { type: 2 as const, id: 987_654_321n };
 const MEMO_ID_BYTES = Memo.encode(MEMO_ID_VALUE);
 
@@ -37,93 +38,44 @@ const PAYMENTS_100 = Array.from({ length: 100 }, (_, i) => makePayment(i));
 const PAYMENT_ARRAY_BYTES = PaymentArray.encode(PAYMENTS_100);
 
 describe('enum', () => {
-  bench('encode', () => void Color.encode(Color.green), BENCH_OPTS);
-  bench('decode', () => void Color.decode(COLOR_BYTES), BENCH_OPTS);
+  b('encode', () => void Color.encode(Color.green));
+  b('decode', () => void Color.decode(COLOR_BYTES));
 });
 
 describe('struct', () => {
-  bench(
-    'encode flat (3 fields)',
-    () => void Range.encode(RANGE_VALUE),
-    BENCH_OPTS
-  );
-  bench(
-    'decode flat (3 fields)',
-    () => void Range.decode(RANGE_BYTES),
-    BENCH_OPTS
-  );
-  bench('encode nested', () => void Line.encode(LINE_VALUE), BENCH_OPTS);
-  bench('decode nested', () => void Line.decode(LINE_BYTES), BENCH_OPTS);
+  b('encode flat (3 fields)', () => void Range.encode(RANGE_VALUE));
+  b('decode flat (3 fields)', () => void Range.decode(RANGE_BYTES));
+  b('encode nested', () => void Line.encode(LINE_VALUE));
+  b('decode nested', () => void Line.decode(LINE_BYTES));
 });
 
 describe('union', () => {
-  bench('encode void arm', () => void Memo.encode({ type: 0 }), BENCH_OPTS);
-  bench('decode void arm', () => void Memo.decode(MEMO_VOID_BYTES), BENCH_OPTS);
-  bench(
-    'encode payload arm',
-    () => void Memo.encode(MEMO_ID_VALUE),
-    BENCH_OPTS
-  );
-  bench(
-    'decode payload arm',
-    () => void Memo.decode(MEMO_ID_BYTES),
-    BENCH_OPTS
-  );
+  b('encode void arm', () => void Memo.encode(MEMO_VOID_VALUE));
+  b('decode void arm', () => void Memo.decode(MEMO_VOID_BYTES));
+  b('encode payload arm', () => void Memo.encode(MEMO_ID_VALUE));
+  b('decode payload arm', () => void Memo.decode(MEMO_ID_BYTES));
 });
 
 describe('option', () => {
-  bench('encode present', () => void OptInt.encode(7), BENCH_OPTS);
-  bench(
-    'decode present',
-    () => void OptInt.decode(OPT_PRESENT_BYTES),
-    BENCH_OPTS
-  );
-  bench('encode absent', () => void OptInt.encode(null), BENCH_OPTS);
-  bench(
-    'decode absent',
-    () => void OptInt.decode(OPT_ABSENT_BYTES),
-    BENCH_OPTS
-  );
+  b('encode present', () => void OptInt.encode(7));
+  b('decode present', () => void OptInt.decode(OPT_PRESENT_BYTES));
+  b('encode absent', () => void OptInt.encode(null));
+  b('decode absent', () => void OptInt.decode(OPT_ABSENT_BYTES));
 });
 
 describe('array of int32', () => {
-  bench('encode 10 elements', () => void IntArray.encode(INTS_10), BENCH_OPTS);
-  bench(
-    'decode 10 elements',
-    () => void IntArray.decode(INT_ARRAY_10_BYTES),
-    BENCH_OPTS
-  );
-  bench(
-    'encode 1000 elements',
-    () => void IntArray.encode(INTS_1000),
-    BENCH_OPTS
-  );
-  bench(
-    'decode 1000 elements',
-    () => void IntArray.decode(INT_ARRAY_1000_BYTES),
-    BENCH_OPTS
-  );
-  bench(
-    'encode 1000 elements (fixed)',
-    () => void IntFixedArray.encode(INTS_1000),
-    BENCH_OPTS
-  );
-  bench(
+  b('encode 10 elements', () => void IntArray.encode(INTS_10));
+  b('decode 10 elements', () => void IntArray.decode(INT_ARRAY_10_BYTES));
+  b('encode 1000 elements', () => void IntArray.encode(INTS_1000));
+  b('decode 1000 elements', () => void IntArray.decode(INT_ARRAY_1000_BYTES));
+  b('encode 1000 elements (fixed)', () => void IntFixedArray.encode(INTS_1000));
+  b(
     'decode 1000 elements (fixed)',
-    () => void IntFixedArray.decode(INT_FIXED_1000_BYTES),
-    BENCH_OPTS
+    () => void IntFixedArray.decode(INT_FIXED_1000_BYTES)
   );
 });
 
 describe('array of structs', () => {
-  bench(
-    'encode 100 payments',
-    () => void PaymentArray.encode(PAYMENTS_100),
-    BENCH_OPTS
-  );
-  bench(
-    'decode 100 payments',
-    () => void PaymentArray.decode(PAYMENT_ARRAY_BYTES),
-    BENCH_OPTS
-  );
+  b('encode 100 payments', () => void PaymentArray.encode(PAYMENTS_100));
+  b('decode 100 payments', () => void PaymentArray.decode(PAYMENT_ARRAY_BYTES));
 });

--- a/bench/js-xdr-v4.d.ts
+++ b/bench/js-xdr-v4.d.ts
@@ -1,0 +1,30 @@
+// The v4 package ships no type declarations. This hand-written surface covers
+// only what the comparison bench touches; it is not a faithful v4 typing.
+declare module 'js-xdr-v4' {
+  export interface V4Builder {
+    enum(name: string, members: Record<string, number>): void;
+    struct(name: string, fields: [string, unknown][]): void;
+    union(name: string, spec: object): void;
+    lookup(name: string): unknown;
+    opaque(length: number): unknown;
+    string(maxLength: number): unknown;
+    void(): unknown;
+    uint(): unknown;
+    hyper(): unknown;
+    uhyper(): unknown;
+    array(childType: unknown, length: number): unknown;
+    varArray(childType: unknown, maxLength: number): unknown;
+  }
+
+  export interface V4Value {
+    toXDR(): Buffer;
+  }
+
+  export interface V4Type {
+    fromXDR(input: Buffer): V4Value;
+  }
+
+  export function config(
+    define: (xdr: V4Builder) => void
+  ): Record<string, V4Type>;
+}

--- a/bench/primitives.bench.ts
+++ b/bench/primitives.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe } from 'vitest';
+import { describe } from 'vitest';
 import {
   bool,
   double,
@@ -8,7 +8,7 @@ import {
   uint32,
   uint64
 } from '../src/index.js';
-import { BENCH_OPTS } from './_fixtures.js';
+import { b } from './_bench.js';
 
 const Bool = bool();
 const Int32 = int32();
@@ -27,36 +27,36 @@ const FLOAT_BYTES = Float.encode(1.5);
 const DOUBLE_BYTES = Double.encode(1.234567890123);
 
 describe('bool', () => {
-  bench('encode', () => void Bool.encode(true), BENCH_OPTS);
-  bench('decode', () => void Bool.decode(BOOL_BYTES), BENCH_OPTS);
+  b('encode', () => void Bool.encode(true));
+  b('decode', () => void Bool.decode(BOOL_BYTES));
 });
 
 describe('int32', () => {
-  bench('encode', () => void Int32.encode(-123_456), BENCH_OPTS);
-  bench('decode', () => void Int32.decode(INT32_BYTES), BENCH_OPTS);
+  b('encode', () => void Int32.encode(-123_456));
+  b('decode', () => void Int32.decode(INT32_BYTES));
 });
 
 describe('uint32', () => {
-  bench('encode', () => void Uint32.encode(123_456), BENCH_OPTS);
-  bench('decode', () => void Uint32.decode(UINT32_BYTES), BENCH_OPTS);
+  b('encode', () => void Uint32.encode(123_456));
+  b('decode', () => void Uint32.decode(UINT32_BYTES));
 });
 
 describe('int64', () => {
-  bench('encode', () => void Int64.encode(-1_234_567_890_123n), BENCH_OPTS);
-  bench('decode', () => void Int64.decode(INT64_BYTES), BENCH_OPTS);
+  b('encode', () => void Int64.encode(-1_234_567_890_123n));
+  b('decode', () => void Int64.decode(INT64_BYTES));
 });
 
 describe('uint64', () => {
-  bench('encode', () => void Uint64.encode(1_234_567_890_123n), BENCH_OPTS);
-  bench('decode', () => void Uint64.decode(UINT64_BYTES), BENCH_OPTS);
+  b('encode', () => void Uint64.encode(1_234_567_890_123n));
+  b('decode', () => void Uint64.decode(UINT64_BYTES));
 });
 
 describe('float', () => {
-  bench('encode', () => void Float.encode(1.5), BENCH_OPTS);
-  bench('decode', () => void Float.decode(FLOAT_BYTES), BENCH_OPTS);
+  b('encode', () => void Float.encode(1.5));
+  b('decode', () => void Float.decode(FLOAT_BYTES));
 });
 
 describe('double', () => {
-  bench('encode', () => void Double.encode(1.234567890123), BENCH_OPTS);
-  bench('decode', () => void Double.decode(DOUBLE_BYTES), BENCH_OPTS);
+  b('encode', () => void Double.encode(1.234567890123));
+  b('decode', () => void Double.decode(DOUBLE_BYTES));
 });

--- a/bench/primitives.bench.ts
+++ b/bench/primitives.bench.ts
@@ -1,0 +1,62 @@
+import { bench, describe } from 'vitest';
+import {
+  bool,
+  double,
+  float,
+  int32,
+  int64,
+  uint32,
+  uint64
+} from '../src/index.js';
+import { BENCH_OPTS } from './_fixtures.js';
+
+const Bool = bool();
+const Int32 = int32();
+const Uint32 = uint32();
+const Int64 = int64();
+const Uint64 = uint64();
+const Float = float();
+const Double = double();
+
+const BOOL_BYTES = Bool.encode(true);
+const INT32_BYTES = Int32.encode(-123_456);
+const UINT32_BYTES = Uint32.encode(123_456);
+const INT64_BYTES = Int64.encode(-1_234_567_890_123n);
+const UINT64_BYTES = Uint64.encode(1_234_567_890_123n);
+const FLOAT_BYTES = Float.encode(1.5);
+const DOUBLE_BYTES = Double.encode(1.234567890123);
+
+describe('bool', () => {
+  bench('encode', () => void Bool.encode(true), BENCH_OPTS);
+  bench('decode', () => void Bool.decode(BOOL_BYTES), BENCH_OPTS);
+});
+
+describe('int32', () => {
+  bench('encode', () => void Int32.encode(-123_456), BENCH_OPTS);
+  bench('decode', () => void Int32.decode(INT32_BYTES), BENCH_OPTS);
+});
+
+describe('uint32', () => {
+  bench('encode', () => void Uint32.encode(123_456), BENCH_OPTS);
+  bench('decode', () => void Uint32.decode(UINT32_BYTES), BENCH_OPTS);
+});
+
+describe('int64', () => {
+  bench('encode', () => void Int64.encode(-1_234_567_890_123n), BENCH_OPTS);
+  bench('decode', () => void Int64.decode(INT64_BYTES), BENCH_OPTS);
+});
+
+describe('uint64', () => {
+  bench('encode', () => void Uint64.encode(1_234_567_890_123n), BENCH_OPTS);
+  bench('decode', () => void Uint64.decode(UINT64_BYTES), BENCH_OPTS);
+});
+
+describe('float', () => {
+  bench('encode', () => void Float.encode(1.5), BENCH_OPTS);
+  bench('decode', () => void Float.decode(FLOAT_BYTES), BENCH_OPTS);
+});
+
+describe('double', () => {
+  bench('encode', () => void Double.encode(1.234567890123), BENCH_OPTS);
+  bench('decode', () => void Double.decode(DOUBLE_BYTES), BENCH_OPTS);
+});

--- a/bench/realistic.bench.ts
+++ b/bench/realistic.bench.ts
@@ -1,0 +1,28 @@
+import { bench, describe } from 'vitest';
+import {
+  BENCH_OPTS,
+  LinkedList,
+  LIST_BYTES,
+  LIST_VALUE,
+  Transaction,
+  TX_BYTES,
+  TX_VALUE
+} from './_fixtures.js';
+
+// A transaction-shaped schema: nested unions, enums, opaques, bigint fields,
+// and a 20-operation array. Closest to how the Stellar SDK uses this library.
+describe('transaction (20 operations)', () => {
+  bench('encode', () => void Transaction.encode(TX_VALUE), BENCH_OPTS);
+  bench('decode', () => void Transaction.decode(TX_BYTES), BENCH_OPTS);
+  bench(
+    'round trip',
+    () => void Transaction.decode(Transaction.encode(TX_VALUE)),
+    BENCH_OPTS
+  );
+});
+
+// Recursion through lazy + option; stresses the depth-tracking machinery.
+describe('recursive list (300 nodes)', () => {
+  bench('encode', () => void LinkedList.encode(LIST_VALUE), BENCH_OPTS);
+  bench('decode', () => void LinkedList.decode(LIST_BYTES), BENCH_OPTS);
+});

--- a/bench/realistic.bench.ts
+++ b/bench/realistic.bench.ts
@@ -1,6 +1,6 @@
-import { bench, describe } from 'vitest';
+import { describe } from 'vitest';
+import { b } from './_bench.js';
 import {
-  BENCH_OPTS,
   LinkedList,
   LIST_BYTES,
   LIST_VALUE,
@@ -12,17 +12,13 @@ import {
 // A transaction-shaped schema: nested unions, enums, opaques, bigint fields,
 // and a 20-operation array. Closest to how the Stellar SDK uses this library.
 describe('transaction (20 operations)', () => {
-  bench('encode', () => void Transaction.encode(TX_VALUE), BENCH_OPTS);
-  bench('decode', () => void Transaction.decode(TX_BYTES), BENCH_OPTS);
-  bench(
-    'round trip',
-    () => void Transaction.decode(Transaction.encode(TX_VALUE)),
-    BENCH_OPTS
-  );
+  b('encode', () => void Transaction.encode(TX_VALUE));
+  b('decode', () => void Transaction.decode(TX_BYTES));
+  b('round trip', () => void Transaction.decode(Transaction.encode(TX_VALUE)));
 });
 
 // Recursion through lazy + option; stresses the depth-tracking machinery.
 describe('recursive list (300 nodes)', () => {
-  bench('encode', () => void LinkedList.encode(LIST_VALUE), BENCH_OPTS);
-  bench('decode', () => void LinkedList.decode(LIST_BYTES), BENCH_OPTS);
+  b('encode', () => void LinkedList.encode(LIST_VALUE));
+  b('decode', () => void LinkedList.decode(LIST_BYTES));
 });

--- a/bench/v4-compare.bench.ts
+++ b/bench/v4-compare.bench.ts
@@ -1,0 +1,84 @@
+import { describe } from 'vitest';
+import * as XDR4 from 'js-xdr-v4';
+import { b } from './_bench.js';
+import { Transaction, TX_BYTES, TX_VALUE } from './_fixtures.js';
+
+// Mirrors the Transaction fixture schema in the v4 API so encode/decode of
+// the same wire bytes can be compared across major versions. The round-trip
+// guard below proves the mirror is wire-identical.
+const v4 = XDR4.config((xdr) => {
+  xdr.enum('PublicKeyType', { ed25519: 0 });
+
+  xdr.union('PublicKey', {
+    switchOn: xdr.lookup('PublicKeyType'),
+    switches: [['ed25519', 'ed25519']],
+    arms: { ed25519: xdr.opaque(32) }
+  });
+
+  xdr.enum('AssetType', { native: 0, credit: 1 });
+
+  xdr.struct('CreditAsset', [
+    ['code', xdr.opaque(4)],
+    ['issuer', xdr.lookup('PublicKey')]
+  ]);
+
+  xdr.union('Asset', {
+    switchOn: xdr.lookup('AssetType'),
+    switches: [
+      ['native', xdr.void()],
+      ['credit', 'credit']
+    ],
+    arms: { credit: xdr.lookup('CreditAsset') }
+  });
+
+  xdr.enum('MemoType', { none: 0, text: 1, id: 2, hash: 3 });
+
+  xdr.union('Memo', {
+    switchOn: xdr.lookup('MemoType'),
+    switches: [
+      ['none', xdr.void()],
+      ['text', 'text'],
+      ['id', 'id'],
+      ['hash', 'hash']
+    ],
+    arms: { text: xdr.string(28), id: xdr.uhyper(), hash: xdr.opaque(32) }
+  });
+
+  xdr.struct('Payment', [
+    ['destination', xdr.lookup('PublicKey')],
+    ['asset', xdr.lookup('Asset')],
+    ['amount', xdr.hyper()]
+  ]);
+
+  xdr.struct('Transaction', [
+    ['source', xdr.lookup('PublicKey')],
+    ['fee', xdr.uint()],
+    ['seqNum', xdr.hyper()],
+    ['memo', xdr.lookup('Memo')],
+    ['operations', xdr.varArray(xdr.lookup('Payment'), 100)],
+    ['signatures', xdr.varArray(xdr.array(xdr.opaque(64), 1), 20)]
+  ]);
+});
+
+// Decoding the v5 fixture bytes through the v4 schema yields the v4-native
+// value shape (class instances, Hyper wrappers) so the encode bench measures
+// v4 on its own terms rather than through a conversion layer.
+const V4Transaction = v4.Transaction;
+if (V4Transaction === undefined) {
+  throw new Error('v4 mirror schema did not define Transaction');
+}
+
+const TX_BUFFER = Buffer.from(TX_BYTES);
+const V4_TX_VALUE = V4Transaction.fromXDR(TX_BUFFER);
+const V4_TX_BYTES: Buffer = V4_TX_VALUE.toXDR();
+
+if (!V4_TX_BYTES.equals(TX_BUFFER)) {
+  throw new Error('v4 mirror schema is not wire-compatible with the fixture');
+}
+
+describe('v4 vs v5: transaction (20 operations)', () => {
+  b('v5 encode', () => void Transaction.encode(TX_VALUE));
+  b('v4 encode', () => void V4_TX_VALUE.toXDR());
+  b('v5 decode', () => void Transaction.decode(TX_BYTES));
+  b('v4 decode', () => void V4Transaction.fromXDR(TX_BUFFER));
+});

--- a/bench/validation.bench.ts
+++ b/bench/validation.bench.ts
@@ -1,0 +1,56 @@
+import { describe } from 'vitest';
+import { b } from './_bench.js';
+import { Transaction, TX_BYTES, TX_VALUE } from './_fixtures.js';
+
+// validateXdr and validate wrap decode/encode in a try/catch, so accepting
+// costs a full parse and rejecting also pays for throwing and catching an
+// XdrError. These benches time both outcomes on transaction-sized input.
+
+// Rejected at the very end: the parse succeeds, then reader.done() sees the
+// leftover bytes. Measures a full decode plus the throw/catch overhead.
+const TX_TRAILING = new Uint8Array(TX_BYTES.length + 4);
+TX_TRAILING.set(TX_BYTES);
+
+// Rejected early: the memo discriminant sits after source (36 B), fee (4 B),
+// and seqNum (8 B), so corrupting the int32 at offset 48 fails the parse
+// 52 bytes in.
+const MEMO_TYPE_OFFSET = 48;
+const TX_BAD_DISCRIMINANT = TX_BYTES.slice();
+new DataView(TX_BAD_DISCRIMINANT.buffer).setUint32(
+  MEMO_TYPE_OFFSET,
+  0xffff_ffff,
+  false
+);
+
+// Guard the fixtures: each corrupted buffer must actually be rejected, or the
+// reject benches would silently measure the accept path.
+if (
+  !Transaction.validateXdr(TX_BYTES) ||
+  Transaction.validateXdr(TX_TRAILING) ||
+  Transaction.validateXdr(TX_BAD_DISCRIMINANT)
+) {
+  throw new Error('validation bench fixtures are wrong');
+}
+
+const TX_BAD_VALUE = { ...TX_VALUE, fee: -1 };
+
+if (!Transaction.validate(TX_VALUE) || Transaction.validate(TX_BAD_VALUE)) {
+  throw new Error('validation bench values are wrong');
+}
+
+describe('validateXdr (transaction bytes)', () => {
+  b('accept', () => void Transaction.validateXdr(TX_BYTES));
+  b(
+    'reject early (bad enum)',
+    () => void Transaction.validateXdr(TX_BAD_DISCRIMINANT)
+  );
+  b(
+    'reject late (trailing bytes)',
+    () => void Transaction.validateXdr(TX_TRAILING)
+  );
+});
+
+describe('validate (transaction value)', () => {
+  b('accept', () => void Transaction.validate(TX_VALUE));
+  b('reject (bad fee)', () => void Transaction.validate(TX_BAD_VALUE));
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build": "pnpm run clean && rollup -c rollup.config.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench": "vitest bench --run",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "check:package-types": "attw --pack .",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "vitest bench --run",
+    "bench:baseline": "vitest bench --run --outputJson bench-baseline.json",
+    "bench:compare": "vitest bench --run --compare bench-baseline.json",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "check:package-types": "attw --pack .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
+  "include": ["src/**/*", "test/**/*", "bench/**/*", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['test/unit/**/*.test.ts']
+    include: ['test/unit/**/*.test.ts'],
+    benchmark: {
+      include: ['bench/**/*.bench.ts']
+    }
   }
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from 'vitest/config';
+import { BenchmarkReporter } from 'vitest/reporters';
+
+// The stock bench reporter ends every run with a "BENCH Summary" block of
+// pairwise "Nx faster than" lines, comparing unrelated cases that merely share
+// a describe group. There is no config switch for it, so silence the hook.
+class NoSummaryBenchmarkReporter extends BenchmarkReporter {
+  override reportBenchmarkSummary(): void {}
+}
 
 export default defineConfig({
   test: {
     include: ['test/unit/**/*.test.ts'],
     benchmark: {
-      include: ['bench/**/*.bench.ts']
+      include: ['bench/**/*.bench.ts'],
+      reporters: [new NoSummaryBenchmarkReporter()]
     }
   }
 });


### PR DESCRIPTION
## What

Adds a `vitest bench` suite covering primitives, bytes/strings, composite types (struct, union, array, option), padding/bool paths, `validateXdr`/accept-reject validation, and a realistic transaction round-trip. Includes a head-to-head comparison against published js-xdr v4, shared fixtures and a bench wrapper in `bench/`, plus `npm` scripts to capture a baseline and compare runs against it.